### PR TITLE
Fix OSL string params when they are empty or contain spaces.

### DIFF
--- a/appleseed-1.5.2-beta/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.cpp
+++ b/appleseed-1.5.2-beta/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.cpp
@@ -43,6 +43,7 @@ namespace renderer
 //
 
 ShaderParamParser::ShaderParamParser(const string& s)
+  : m_original_string(s)
 {
     tokenize(s, Blanks, m_tokens);
 
@@ -106,12 +107,9 @@ string ShaderParamParser::parse_string_value()
 {
     assert(param_type() == OSLParamTypeString);
 
-    const string val(*m_tok_it++);
-
-    if (m_tok_it != m_tok_end)
-        throw ExceptionOSLParamParseError();
-
-    return val;
+    // Remove the string prefix and trim whitespace.
+    string val(m_original_string, 6, string::npos);
+    return trim_both(val);
 }
 
 }   // namespace renderer

--- a/appleseed-1.5.2-beta/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.h
+++ b/appleseed-1.5.2-beta/src/appleseed/renderer/modeling/shadergroup/shaderparamparser.h
@@ -84,6 +84,7 @@ class ShaderParamParser
     std::string parse_string_value();
 
   private:
+    std::string m_original_string;
     std::vector<std::string>                    m_tokens;
     OSLParamType                                m_param_type;
     std::vector<std::string>::const_iterator    m_tok_it;


### PR DESCRIPTION
This is copied from https://github.com/appleseedhq/appleseed/commit/03c5f49993f6993b166d978630b185acc24cb6b1, and is a temporary measure until we can update to the latest appleseed version.