### PR TITLE
Include Qt build tools in packaged dependencies

### DIFF
--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -17,6 +17,11 @@ cd $BUILD_DIR
 
 manifest="
 
+	bin/moc
+	bin/qmake
+	bin/rcc
+	bin/uic
+	
 	bin/python
 	bin/python*[0-9]
 


### PR DESCRIPTION
You were right!  `qmake`, `moc`, et al were installed with `-nomake tools` intact.  Must have been `LD_LIBRARY_PATH` that was causing them not to get installed into the destination build dir.  Is an increase of ~3MB okay?  I go from ~150MB -> ~153MB of the final archive when I add `moc`, `qmake`, `rcc`, and `uic` to the manifest.  ( `rcc` and `uic` aren't necessary for SeExpr, but they might be useful for other developers/packages that make use of .ui and .qrc files).