### PR TITLE
TBB : Build for C++11

### DIFF
--- a/build/buildTBB.sh
+++ b/build/buildTBB.sh
@@ -7,12 +7,6 @@ cd `dirname $0`/../tbb43_20150611oss
 mkdir -p $BUILD_DIR/doc/licenses
 cp COPYING $BUILD_DIR/doc/licenses/tbb
 
-if [[ -z $CXX ]] ; then
-	# tbb will prefer gcc over clang unless explicitly told otherwise,
-	# but fails to build with clang 2.1 on OS X 10.7.
-	export CXX=gcc
-fi
-
 # If our default shell is not Bash, TBB's own build system
 # may not be able to properly figure out which OS we're on,
 # so set it manually here.
@@ -22,7 +16,7 @@ else
     export tbb_os=macos
 fi
 
-make clean && make compiler=$CXX
+make clean && make cpp0x=1
 
 cp -r include/tbb $BUILD_DIR/include
 


### PR DESCRIPTION
Without this we get these runtime warnings when linking against TBB from C++11-enabled Gaffer and Cortex :

```
TBB Warning: Exact exception propagation is requested by application but the linked library is built without support for it
```