### PR TITLE
Packaging : Remove python-config

### DIFF
--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -25,9 +25,7 @@ manifest="
 	bin/uic
 
 	bin/python
-	bin/python-config
 	bin/python*[0-9]
-	bin/python*[0-9]-config
 
 	bin/exrheader
 	bin/maketx


### PR DESCRIPTION
It is not suitable for packaging because it is not relocatable - it contains hardcoded paths to the build location, and looks for python there.