### PR TITLE
Packaging : Include libboost_test_exec_monitor.a

### DIFF
--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -43,6 +43,7 @@ manifest="
 	bin/abctree
 
 	lib/libboost_*$SHLIBSUFFIX*
+	lib/libboost_test_exec_monitor.a
 
 	lib/libIECore*$SHLIBSUFFIX
 


### PR DESCRIPTION
This is only available as a static library and so escaped the packaging of all dynamic boost libraries. It is needed in order to run the Cortex unit tests.