### PR TITLE
EXR : Package imath module in python subdirectory

### DIFF
--- a/build/buildEXR.sh
+++ b/build/buildEXR.sh
@@ -22,6 +22,9 @@ cp COPYING $BUILD_DIR/doc/licenses/pyilmbase
 
 ./configure --prefix=$BUILD_DIR --with-boost-include-dir=$BUILD_DIR/include --without-numpy && make clean && make && make install
 
+mv $BUILD_DIR/lib/python*/site-packages/iexmodule.so $BUILD_DIR/python
+mv $BUILD_DIR/lib/python*/site-packages/imathmodule.so $BUILD_DIR/python
+
 popd
 
 pushd `dirname $0`/../openexr-2.2.0

--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -105,6 +105,8 @@ manifest="
 	python/PyOpenColorIO*
 	python/Qt.py
 	python/pyopenvdb*
+	python/iexmodule*
+	python/imathmodule*
 
 	include/IECore*
 	include/boost


### PR DESCRIPTION
The lib/python2.7/site-packages directory it installs in by default is not on the default PYTHONPATH on mac (because all that jazz is inside Python.framework instead).