### PR TITLE
USD : Add build of version 0.8.2

### DIFF
--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -40,6 +40,9 @@ manifest="
 	bin/abcstitcher
 	bin/abctree
 
+	bin/usd*
+	bin/sdfdump
+
 	lib/libboost_*$SHLIBSUFFIX*
 	lib/libboost_test_exec_monitor.a
 
@@ -83,6 +86,20 @@ manifest="
 	lib/libopenvdb*$SHLIBSUFFIX*
 	lib/libblosc*$SHLIBSUFFIX*
 
+	lib/libtracelite$SHLIBSUFFIX
+	lib/libarch$SHLIBSUFFIX
+	lib/libtf$SHLIBSUFFIX
+	lib/libjs$SHLIBSUFFIX
+	lib/libwork$SHLIBSUFFIX
+	lib/libplug$SHLIBSUFFIX
+	lib/libkind$SHLIBSUFFIX
+	lib/libgf$SHLIBSUFFIX
+	lib/libvt$SHLIBSUFFIX
+	lib/libar$SHLIBSUFFIX
+	lib/libsdf$SHLIBSUFFIX
+	lib/libpcp$SHLIBSUFFIX
+	lib/libusd*$SHLIBSUFFIX
+
 	fonts
 	resources
 	shaders
@@ -106,6 +123,7 @@ manifest="
 	python/pyopenvdb*
 	python/iexmodule*
 	python/imathmodule*
+	python/pxr
 
 	include/IECore*
 	include/boost
@@ -128,11 +146,14 @@ manifest="
 	include/jmorecfg.h
 	include/jpeglib.h
 	include/pyopenvdb.h
+	include/pxr
 
 	renderMan
 	arnold
 
 	appleseedDisplays
+
+	share/usd
 
 	appleseed/bin/appleseed.cli
 	appleseed/include

--- a/build/buildUSD.sh
+++ b/build/buildUSD.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+usdVersion="0.8.2"
+
+workingDir=`dirname $0`/../working/usd
+rm -rf $workingDir
+mkdir -p $workingDir
+cd $workingDir
+
+archive=USD-$usdVersion.tar.gz
+cp ../../archives/$archive ./
+tar -xf $archive
+
+cd USD-$usdVersion
+
+cp LICENSE.txt $BUILD_DIR/doc/licenses/usd
+
+export LD_LIBRARY_PATH=$BUILD_DIR/lib
+
+cmake \
+	-D CMAKE_PREFIX_PATH=$BUILD_DIR \
+	-D CMAKE_INSTALL_PREFIX=$BUILD_DIR \
+	-D Boost_NO_BOOST_CMAKE=TRUE \
+	-D PXR_BUILD_IMAGING=FALSE \
+	-D PXR_BUILD_TESTS=FALSE \
+	.
+
+make install -j `getconf _NPROCESSORS_ONLN` VERBOSE=1
+
+mv $BUILD_DIR/lib/python/pxr $BUILD_DIR/python


### PR DESCRIPTION
This will be used to support USD loading via IECoreUSD and GafferScene::SceneReader.

Requires an update to a Cortex version including https://github.com/ImageEngine/cortex/pull/679, as otherwise the Cortex build will fail.