### PR TITLE
Qt5 : include cmake files in package

### DIFF
--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -79,6 +79,8 @@ manifest="
 
 	lib/libQt*
 	lib/Qt*.framework
+	lib/cmake
+	mkspecs
 
 	lib/libxerces-c*$SHLIBSUFFIX*
 


### PR DESCRIPTION
Copies the files from the Qt installation required to build with Gaffer with CMake.