### PR TITLE
buildPackage : include blosc headers in dependencies package

### DIFF
--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -137,6 +137,7 @@ manifest="
 	include/freetype2
 	include/Alembic
 	include/openvdb
+	include/blosc*.h
 	include/tiff*
 	include/png*
 	include/libpng*


### PR DESCRIPTION
In case gaffer or cortex need to compile directly against blosc.


