### PR TITLE
PySide : Fix build

### DIFF
--- a/pyside-setup-6d8dee0/ez_setup.py
+++ b/pyside-setup-6d8dee0/ez_setup.py
@@ -205,7 +205,7 @@ def has_powershell():
 download_file_powershell.viable = has_powershell
 
 def download_file_curl(url, target):
-    cmd = ['curl', url, '--silent', '--output', target]
+    cmd = ['curl', url, '-L', '--silent', '--output', target]
     _clean_check(cmd, target)
 
 def has_curl():


### PR DESCRIPTION
The internet is broken. A file that ez_setup.py wants to download has been moved, so we must add the `-L` argument to `curl` so that it follows the redirect.