### PR TITLE
OpenSubdiv : Added OpenSubdiv as a dependency, version 3.3.3

### DIFF
--- a/OpenSubdiv/config.py
+++ b/OpenSubdiv/config.py
@@ -1,0 +1,40 @@
+{
+
+	"downloads" : [
+
+		"https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v3_3_3.tar.gz"
+
+	],
+
+	"license" : "LICENSE.txt",
+
+	"commands" : [
+
+		"mkdir gafferBuild",
+		"cd gafferBuild &&"
+			" cmake"
+			" -G \"Unix Makefiles\""
+			" -D CMAKE_INSTALL_PREFIX={buildDir}"
+			" -D CMAKE_PREFIX_PATH={buildDir}"
+			" -D NO_EXAMPLES=1"
+			" -D NO_TUTORIALS=1"
+			" -D NO_REGRESSION=1"
+			" -D NO_PTEX=1"
+			" -D NO_DOC=1"
+			" -D NO_OMP=1"
+			" -D NO_CUDA=1"
+			" -D NO_OPENCL=1"
+			" -D NO_CLEW=1"
+			" -D NO_METAL=1"
+			" -D NO_DX=1"
+			" -D NO_TESTS=1"
+			" -D NO_GLTESTS=1"
+			" -D NO_GLFW=1"
+			" -D NO_GLFW_X11=1"
+			" -D GLEW_LOCATION={buildDir}"
+			" ..",
+		"cd gafferBuild && make install -j {jobs} VERBOSE=1"
+
+	],
+
+}


### PR DESCRIPTION
For future purposes..... :) didn't add to buildAll.sh in this one, only the OpenGL and TBB backends are built with all other backends and tests/regressions/etc. disabled. Tested on Linux.