### PR TITLE
OSL/OIIO docs

### DIFF
--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -18,7 +18,8 @@
 			" -D CMAKE_PREFIX_PATH={buildDir}"
 			" -D USE_FFMPEG=NO"
 			" ..",
-		"cd gafferBuild && make install -j {jobs} VERBOSE=1"
+		"cd gafferBuild && make install -j {jobs} VERBOSE=1",
+		"cp {buildDir}/share/doc/OpenImageIO/openimageio.pdf {buildDir}/doc",
 
 	],
 

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -29,7 +29,8 @@
 			" -D ENABLERTTI=1"
 			" -D LLVM_STATIC=1"
 			" ..",
-		"cd gafferBuild && make install -j {jobs} VERBOSE=1"
+		"cd gafferBuild && make install -j {jobs} VERBOSE=1",
+		"cp {buildDir}/share/doc/OSL/osl-languagespec.pdf {buildDir}/doc",
 
 	],
 

--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -115,6 +115,7 @@ manifest="
 	doc/licenses
 	doc/cortex/html
 	doc/osl*
+	doc/openimageio.pdf
 
 	python/IECore*
 	python/9to10


### PR DESCRIPTION
This fixes the installation of the OSL docs, and adds the OIIO docs as well. @medubelko, the latter is following on from our "Anatomy of an Image" discussion. Once we install the OIIO docs we can add a menu item to open them and then from our own documentation, point users to the Appendix that discusses image metadata.