### PR TITLE
USD : Fix python module linking on MacOS

### DIFF
--- a/USD/config.py
+++ b/USD/config.py
@@ -8,7 +8,7 @@
 
 	"license" : "LICENSE.txt",
 
-		"commands" : [
+	"commands" : [
 
 		"cmake"
 			" -D CMAKE_INSTALL_PREFIX={buildDir}"
@@ -17,6 +17,8 @@
 			" -D Boost_NO_BOOST_CMAKE=TRUE"
 			" -D PXR_BUILD_IMAGING=FALSE"
 			" -D PXR_BUILD_TESTS=FALSE"
+			# Needed to prevent CMake picking up system python libraries on Mac.
+			" -D CMAKE_FRAMEWORK_PATH={buildDir}/lib/Python.framework/Versions/2.7/lib"
 			" ."
 		,
 


### PR DESCRIPTION
Despite finding the right Python interpreter in `{buildDir}`, CMake insisted on using headers/libraries it found in the system.