### PR TITLE
HDF5 : update download URL

### DIFF
--- a/HDF5/config.py
+++ b/HDF5/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.20.tar.gz"
+		"https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.20/src/hdf5-1.8.20.tar.gz"
 
 	],
 


### PR DESCRIPTION
This is a micro-PR reflecting the change in URL for downloading HDF5 1.8.20. The old URL looks to be invalid now.