### PR TITLE
Added support for reading usd files with alembic files references

### DIFF
--- a/USD/config.py
+++ b/USD/config.py
@@ -17,6 +17,10 @@
 			" -D Boost_NO_BOOST_CMAKE=TRUE"
 			" -D PXR_BUILD_IMAGING=FALSE"
 			" -D PXR_BUILD_TESTS=FALSE"
+			" -D PXR_BUILD_ALEMBIC_PLUGIN=TRUE"
+			" -D PXR_ENABLE_HDF5_SUPPORT=FALSE"
+			" -D ALEMBIC_DIR={buildDir}/lib"
+			" -D OPENEXR_LOCATION={buildDir}/lib"
 			# Needed to prevent CMake picking up system python libraries on Mac.
 			" -D CMAKE_FRAMEWORK_PATH={buildDir}/lib/Python.framework/Versions/2.7/lib"
 			" ."


### PR DESCRIPTION
As discussed in the [thread](https://groups.google.com/forum/#!topic/gaffer-dev/bkCJkOFBfh4), I have added the flags in the usd build script to build alembic support as well. Please note that I have disabled HDF5 support but please let me know if its required. Sample [files](https://github.com/GafferHQ/dependencies/files/3243381/usd_alembic_samples.tar.gz) are attached for your reference.

Cheers,
Sachin

