### PR TITLE
Cortex : Make display driver symlink for RenderMan

### DIFF
--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -47,7 +47,8 @@
 			" OPTIONS=''"
 			" SAVE_OPTIONS=gaffer.options",
 
-		"cp -r contrib/scripts/9to10 {buildDir}/python",
+		# Symlink for RenderMan, which uses a different convention to 3Delight.
+		"ln -s ieDisplay.dylib {buildDir}/renderMan/displayDrivers/d_ieDisplay.so"
 
 	],
 

--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -119,7 +119,6 @@ manifest="
 	doc/openimageio.pdf
 
 	python/IECore*
-	python/9to10
 	python/OpenGL
 	python/PyOpenColorIO*
 	python/Qt.py


### PR DESCRIPTION
And remove 9to10 script, now the transition to Cortex 10 is well and truly complete.