### PR TITLE
v1.0.0 : USD, OpenVDB and Cortex updates.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,12 @@
+1.0.0
+-----
+
+Move to Semantic Versioning to describe changes in dependencies, and decouple from GAFFER_VERSION.
+
+- Cortex : Updated to version 10.0.0-a72.
+- USD : Updated to version 20.02.
+- VDB : Updated to version 7.0.0.
+
 0.54.2.0
 --------
 

--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/ImageEngine/cortex/archive/10.0.0-a64.tar.gz"
+		"https://github.com/ImageEngine/cortex/archive/10.0.0-a72.tar.gz"
 
 	],
 

--- a/OpenVDB/config.py
+++ b/OpenVDB/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/openvdb/archive/v6.0.0.tar.gz"
+		"https://github.com/AcademySoftwareFoundation/openvdb/archive/v7.0.0.tar.gz"
 
 	],
 

--- a/USD/config.py
+++ b/USD/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/PixarAnimationStudios/USD/archive/v18.09.tar.gz"
+		"https://github.com/PixarAnimationStudios/USD/archive/v20.02.tar.gz"
 
 	],
 

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@ import sys
 import tarfile
 import zipfile
 
-__version = "0.56.0.0"
+__version = "1.0.0"
 
 def __globalVariables( buildDir ) :
 


### PR DESCRIPTION
We're moving to simple semVer for dependencies, instead of tying it to `GAFFER_VERSION` (Gaffer 55 is already out of sync by using deps from `0.54.2`). This then makes is more apparent when things actually change.

In aid of https://github.com/GafferHQ/gaffer/issues/3585