### PR TITLE
Python 3 foundational work

### DIFF
--- a/Appleseed/config.py
+++ b/Appleseed/config.py
@@ -25,15 +25,6 @@
 
 	},
 
-	"variables" : {
-
-		# Make sure we pick up the python headers from {buildDir},
-		# rather than any system level headers. We refer to this
-		# variable in "commands" below.
-		"pythonIncludeDir" : "{buildDir}/include/python2.7",
-
-	},
-
 	"commands" : [
 
 		"mkdir build",
@@ -76,16 +67,5 @@
 		"appleseed/shaders",
 
 	],
-
-	"platform:osx" : {
-
-		"variables" : {
-
-			# Python headers have a different location on OSX.
-			"pythonIncludeDir" : "{buildDir}/lib/Python.framework/Headers",
-
-		},
-
-	},
 
 }

--- a/Boost/config.py
+++ b/Boost/config.py
@@ -18,7 +18,7 @@
 		"MACOSX_DEPLOYMENT_TARGET" : "10.9",
 		# Give a helping hand to find the python headers, since the bootstrap
 		# below doesn't always seem to get it right.
-		"CPLUS_INCLUDE_PATH" : "{buildDir}/include/python2.7",
+		"CPLUS_INCLUDE_PATH" : "{pythonIncludeDir}",
 
 	},
 

--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -19,6 +19,7 @@
 			" -D CMAKE_INSTALL_LIBDIR={buildDir}/lib"
 			" -D CMAKE_PREFIX_PATH={buildDir}"
 			" -D USE_FFMPEG=NO"
+			" -D USE_PYTHON=NO"
 			" ..",
 		"cd gafferBuild && make install -j {jobs} VERBOSE=1",
 		"cp {buildDir}/share/doc/OpenImageIO/openimageio.pdf {buildDir}/doc",

--- a/OpenVDB/config.py
+++ b/OpenVDB/config.py
@@ -10,12 +10,6 @@
 
 	"dependencies" : [ "Blosc", "TBB", "OpenEXR", "Python" ],
 
-	"variables" : {
-
-		"pythonVersion" : "2.7",
-
-	},
-
 	"commands" : [
 
 		"cd openvdb && make install"
@@ -53,27 +47,5 @@
 		"python/pyopenvdb*",
 
 	],
-
-	"platform:linux" : {
-
-		"variables" : {
-
-			"pythonIncludeDir" : "{buildDir}/include/python{pythonVersion}",
-			"pythonLibDir" : "{buildDir}/lib",
-
-		},
-
-	},
-
-	"platform:osx" : {
-
-		"variables" : {
-
-			"pythonIncludeDir" : "{buildDir}/lib/Python.framework/Headers",
-			"pythonLibDir" : "{buildDir}/lib/Python.framework/Versions/{pythonVersion}",
-
-		},
-
-	},
 
 }

--- a/Python/config.py
+++ b/Python/config.py
@@ -1,5 +1,14 @@
 {
 
+	"publicVariables" : {
+
+		"pythonVersion" : "2.7",
+		"pythonMajorVersion" : "2",
+		"pythonIncludeDir" : "{buildDir}/include/python{pythonVersion}",
+		"pythonLibDir" : "{buildDir}/lib",
+
+	},
+
 	"downloads" : [
 
 		"https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz",
@@ -27,7 +36,7 @@
 
 		"lib/libpython*{sharedLibraryExtension}*",
 		"lib/Python.framework*",
-		"lib/python2.7",
+		"lib/python{pythonVersion}",
 
 	],
 
@@ -45,11 +54,18 @@
 
 		},
 
+		"publicVariables" : {
+
+			"pythonIncludeDir" : "{buildDir}/lib/Python.framework/Headers",
+			"pythonLibDir" : "{buildDir}/lib/Python.framework/Versions/{pythonVersion}/lib",
+
+		},
+
 		"symbolicLinks" : [
 
 			( "{buildDir}/bin/python", "../lib/Python.framework/Versions/Current/bin/python" ),
-			( "{buildDir}/bin/python2", "../lib/Python.framework/Versions/Current/bin/python2" ),
-			( "{buildDir}/bin/python2.7", "../lib/Python.framework/Versions/Current/bin/python2.7" ),
+			( "{buildDir}/bin/python{pythonMajorVersion}", "../lib/Python.framework/Versions/Current/bin/python{pythonMajorVersion}" ),
+			( "{buildDir}/bin/python{pythonVersion}", "../lib/Python.framework/Versions/Current/bin/python{pythonVersion}" ),
 
 		],
 

--- a/USD/config.py
+++ b/USD/config.py
@@ -24,7 +24,7 @@
 			" -D ALEMBIC_DIR={buildDir}/lib"
 			" -D OPENEXR_LOCATION={buildDir}/lib"
 			# Needed to prevent CMake picking up system python libraries on Mac.
-			" -D CMAKE_FRAMEWORK_PATH={buildDir}/lib/Python.framework/Versions/2.7/lib"
+			" -D CMAKE_FRAMEWORK_PATH={pythonLibDir}"
 			" ."
 		,
 

--- a/build.py
+++ b/build.py
@@ -231,6 +231,7 @@ def __buildProject( project, config, buildDir ) :
 		subprocess.check_call( command, shell = True, env = environment )
 
 	for link in config.get( "symbolicLinks", [] ) :
+		sys.stderr.write( "Linking {} to {}\n".format( link[0], link[1] ) )
 		if os.path.exists( link[0] ) :
 			os.remove( link[0] )
 		os.symlink( link[1], link[0] )


### PR DESCRIPTION
This adds a `publicVariables` feature which allows a project config to pass variables to dependent projects. We use that to replace some hardcoding of python locations and versions in various projects, paving the way for us to introduce a Python 3 variant of the builds.