### PR TITLE
Add LibRaw 0.19.5

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,7 @@ This major version introduces the concept of build variants, and provides packag
 - LZ4 : Added version 1.9.2.
 - Cortex : Updated to version 10.0.0-a78.
 - USD : Updated to version 20.05.
+- LibRaw : Added version 0.19.5.
 
 1.2.0
 -----

--- a/LibRaw/config.py
+++ b/LibRaw/config.py
@@ -1,0 +1,28 @@
+{
+
+	"downloads" : [
+
+		"https://www.libraw.org/data/LibRaw-0.19.5.tar.gz",
+
+	],
+
+	"url" : "https://www.libraw.org/",
+
+	"license" : "LICENSE.LGPL",
+
+	"commands" : [
+
+		"./configure --disable-examples --prefix={buildDir}",
+		"make -j {jobs}",
+		"make install"
+
+	],
+
+	"manifest" : [
+
+		"include/libraw",
+		"lib/libraw*{sharedLibraryExtension}*",
+
+	],
+
+}

--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -10,7 +10,7 @@
 
 	"license" : "LICENSE",
 
-	"dependencies" : [ "Boost", "Python", "OpenEXR", "LibTIFF", "LibPNG", "LibJPEG-Turbo", "OpenColorIO" ],
+	"dependencies" : [ "Boost", "Python", "OpenEXR", "LibTIFF", "LibPNG", "LibJPEG-Turbo", "OpenColorIO", "LibRaw" ],
 
 	"commands" : [
 


### PR DESCRIPTION
This could probably do with some further testing, but it does build (and OpenImageIO builds against it) on both Linux and Mac.