### PR TITLE
Build with C++14

### DIFF
--- a/Boost/config.py
+++ b/Boost/config.py
@@ -28,7 +28,7 @@
 	"commands" : [
 
 		"./bootstrap.sh --prefix={buildDir} --with-python={buildDir}/bin/python --with-python-root={buildDir} --without-libraries=log --without-icu",
-		"./bjam -d+2 -j {jobs} --disable-icu cxxflags='-std=c++11' variant=release link=shared threading=multi install",
+		"./bjam -d+2 -j {jobs} --disable-icu cxxflags='-std={c++Standard}' variant=release link=shared threading=multi install",
 
 	],
 

--- a/Changes
+++ b/Changes
@@ -16,6 +16,7 @@ This major version introduces the concept of build variants, and provides packag
 - Cortex : Updated to version 10.0.0-a78.
 - USD : Updated to version 20.05.
 - LibRaw : Added version 0.19.5.
+- Build : Switched standard to C++14.
 
 1.2.0
 -----

--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -28,6 +28,7 @@
 		"scons install installDoc"
 			" -j {jobs}"
 			" CXX=`which g++`"
+			" CXXSTD={c++Standard}"
 			" INSTALL_PREFIX={buildDir}"
 			" INSTALL_DOC_DIR={buildDir}/doc/cortex"
 			" INSTALL_RMANPROCEDURAL_NAME={buildDir}/renderMan/procedurals/iePython"

--- a/TBB/config.py
+++ b/TBB/config.py
@@ -12,7 +12,7 @@
 
 	"commands" : [
 
-		"make -j {jobs} stdver=c++11",
+		"make -j {jobs} stdver={c++Standard}",
 		"cp -r include/tbb {buildDir}/include",
 		"{installLibsCommand}",
 

--- a/build.py
+++ b/build.py
@@ -453,6 +453,7 @@ variables = {
 	"version" : __version,
 	"platform" : "osx" if sys.platform == "darwin" else "linux",
 	"sharedLibraryExtension" : ".dylib" if sys.platform == "darwin" else ".so",
+	"c++Standard" : "c++14",
 	"variants" : "".join( "-{}{}".format( key, variants[key] ) for key in sorted( variants.keys() ) ),
 }
 


### PR DESCRIPTION
This is required to build IECoreUSD, because USD 20.05 now requires C++14. C++14 has been mandated by VFXPlatform since 2018, so we're a little late anyway.