### PR TITLE
Add LibFFI 3.3, and use `--with-system-ffi` for Python

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ This major version introduces the concept of build variants, and provides packag
 - USD : Updated to version 20.05 and added usdImaging.
 - LibRaw : Added version 0.19.5.
 - OpenSubdiv : Added version 3.4.3.
+- LibFFI : Added version 3.3.
 - Build : Switched standard to C++14.
 
 1.2.0

--- a/LibFFI/config.py
+++ b/LibFFI/config.py
@@ -1,0 +1,26 @@
+{
+
+	"downloads" : [
+
+		"https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz"
+
+	],
+
+	"url" : "https://sourceware.org/libffi/",
+	"license" : "LICENSE",
+
+	"commands" : [
+
+		"./configure --prefix={buildDir} --libdir={buildDir}/lib --disable-multi-os-directory",
+		"make -j {jobs}",
+		"make install",
+
+	],
+
+	"manifest" : [
+
+		"lib/libffi*{sharedLibraryExtension}*",
+
+	],
+
+}

--- a/Python/config.py
+++ b/Python/config.py
@@ -13,11 +13,19 @@
 
 	"license" : "LICENSE",
 
-	"dependencies" : [ "OpenSSL" ],
+	"dependencies" : [ "OpenSSL", "LibFFI" ],
+
+	"environment" : {
+
+		"LDFLAGS" : "-L{buildDir}/lib",
+		"CPPFLAGS" : "-I{buildDir}/include",
+		"LD_LIBRARY_PATH" : "{buildDir}/lib",
+
+	},
 
 	"commands" : [
 
-		"./configure --prefix={buildDir} {libraryType} --enable-unicode=ucs4 --with-ensurepip=install",
+		"./configure --prefix={buildDir} {libraryType} --enable-unicode=ucs4 --with-ensurepip=install --with-system-ffi",
 		"make -j {jobs}",
 		"make install",
 


### PR DESCRIPTION
Python 2 used to bundle the source for libffi and use that by default. Python 3 always uses the system libffi on Linux, no matter what you ask it to do, so we need to control the library version to guarantee compatibility on different distros. We are also using own own ffi for Python 2 and on Mac as well for consistency.

Fixes #163.