### PR TITLE
Add Jemalloc 3.6

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ This major version introduces the concept of build variants, and provides packag
 - LibRaw : Added version 0.19.5.
 - OpenSubdiv : Added version 3.4.3.
 - LibFFI : Added version 3.3.
+- Jemalloc : Added version 3.6.0.
 - Build : Switched standard to C++14.
 
 1.2.0

--- a/Jemalloc/config.py
+++ b/Jemalloc/config.py
@@ -1,0 +1,27 @@
+{
+
+	"downloads" : [
+
+		"https://github.com/jemalloc/jemalloc/releases/download/3.6.0/jemalloc-3.6.0.tar.bz2",
+
+	],
+
+	"url" : "http://jemalloc.net/",
+
+	"license" : "COPYING",
+
+	"commands" : [
+
+		"./configure --prefix={buildDir}",
+		"make -j {jobs}",
+		"make install"
+
+	],
+
+	"manifest" : [
+
+		"include/jemalloc",
+		"lib/libjemalloc*{sharedLibraryExtension}*",
+
+	],
+}


### PR DESCRIPTION
This is an older version, the same one as is used in Houdini 18. Reports suggest that later versions may suffer from fragmentation and increased virtual address space.