### PR TITLE
PySide : Link pyside-uic into bin directory on Mac

### DIFF
--- a/PySide/config.py
+++ b/PySide/config.py
@@ -43,6 +43,12 @@
 
 		},
 
+		"symbolicLinks" : [
+
+			( "{buildDir}/bin/pyside2-uic", "../lib/Python.framework/Versions/Current/bin/pyside2-uic" ),
+
+		]
+
 	},
 
 }


### PR DESCRIPTION
This is needed for USD to build.