### PR TITLE
LibFFI : Disable compilation for specific architecture

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+2.x.x
+-----
+
+- LibFFI : Fixed compatibility with pre-haswell era processors.
+
 2.0.0
 -----
 

--- a/LibFFI/config.py
+++ b/LibFFI/config.py
@@ -11,7 +11,7 @@
 
 	"commands" : [
 
-		"./configure --prefix={buildDir} --libdir={buildDir}/lib --disable-multi-os-directory",
+		"./configure --prefix={buildDir} --libdir={buildDir}/lib --disable-multi-os-directory --without-gcc-arch",
 		"make -j {jobs}",
 		"make install",
 


### PR DESCRIPTION
This resulted in binaries which wouldn't run on pre-haswell era architectures, due to a lack of a BSLR instruction.