### PR TITLE
OpenSSL : Include libraries in manifest

### DIFF
--- a/OpenSSL/config.py
+++ b/OpenSSL/config.py
@@ -18,6 +18,13 @@
 
 	],
 
+	"manifest" : [
+
+		"lib/libssl{sharedLibraryExtension}*",
+		"lib/libcrypto{sharedLibraryExtension}*",
+
+	],
+
 	"platform:osx" : {
 
 		"environment" : {


### PR DESCRIPTION
Before we upgraded to 1.1.1.h, the default was to make static libs, so we didn't need to ship them. When we upgraded, OpenSSL switched to building shared libs, but I didn't add them to the manifest. So we ended up building Python modules with dependencies on libs we weren't packaging.