### PR TITLE
 Python : Fix ssl module build

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+3.x.x
+-----
+
+- Python : Fixed `ssl` module for Python 3.
+
 3.0.0
 -----
 

--- a/OpenSSL/config.py
+++ b/OpenSSL/config.py
@@ -14,7 +14,7 @@
 
 		"./config --prefix={buildDir} -fPIC",
 		"make -j {jobs}",
-		"make install",
+		"make install_sw",
 
 	],
 

--- a/Python/config.py
+++ b/Python/config.py
@@ -25,7 +25,7 @@
 
 	"commands" : [
 
-		"./configure --prefix={buildDir} {libraryType} --enable-unicode=ucs4 --with-ensurepip=install --with-system-ffi",
+		"./configure --prefix={buildDir} {libraryType} --enable-unicode=ucs4 --with-ensurepip=install --with-system-ffi --with-openssl={buildDir}",
 		"make -j {jobs}",
 		"make install",
 


### PR DESCRIPTION
As described in https://bugs.python.org/issue32694, `CPPFLAGS` and `LDFLAGS` are no longer used to find OpenSSL, so we must specify the location explicitly using `--with-openssl`.

