### PR TITLE
OpenVDB: Latest CMake has different find_python semantics.

### DIFF
--- a/OpenVDB/config.py
+++ b/OpenVDB/config.py
@@ -31,6 +31,8 @@
 			" -D OPENVDB_ENABLE_RPATH=OFF"
 			" -D CONCURRENT_MALLOC=None"
 			" -D PYOPENVDB_INSTALL_DIRECTORY={buildDir}/python"
+			" -D Python_ROOT_DIR={buildDir}"
+			" -D Python_FIND_STRATEGY=LOCATION"
 			" .."
 		,
 


### PR DESCRIPTION
Needed to build on Ubuntu 20.04 native, CMake 3.21.