### PR TITLE
Build: Latest CMake find_python has different semantics.

### DIFF
--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -33,6 +33,8 @@
 			" -D USE_EXTERNAL_PUGIXML=YES"
 			" -D OIIO_BUILD_TESTS=NO"
 			" {pythonArguments}"
+			" -D Python_ROOT_DIR={buildDir}"
+			" -D Python_FIND_STRATEGY=LOCATION"
 			# These next two disable `iv`. This fails to
 			# build on Mac due to OpenGL deprecations, and
 			# we've never packaged it anyway.

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -35,6 +35,8 @@
 			" -D LLVM_STATIC=1"
 			" -D OSL_BUILD_MATERIALX=1"
 			" -D OSL_SHADER_INSTALL_DIR={buildDir}/shaders"
+			" -D Python_ROOT_DIR={buildDir}"
+			" -D Python_FIND_STRATEGY=LOCATION"
 			" ..",
 		"cd gafferBuild && make install -j {jobs} VERBOSE=1",
 		"cp {buildDir}/share/doc/OSL/osl-languagespec.pdf {buildDir}/doc",

--- a/PyBind11/config.py
+++ b/PyBind11/config.py
@@ -23,7 +23,10 @@
 
 		"cmake"
 		" -D CMAKE_INSTALL_PREFIX={buildDir} ."
-		" -D PYBIND11_TEST=0",
+		" -D PYBIND11_TEST=0"
+		" -D PYBIND11_FINDPYTHON=1"
+		" -D Python_ROOT_DIR={buildDir}"
+		" -D Python_FIND_STRATEGY=LOCATION",
 		"make install",
 
 	],


### PR DESCRIPTION
Hey John, found some more which were using my system Python 3.8 instead. The PyBind11 might need a unit test, not sure if that'll break old stuff.