### PR TITLE
Appleseed: Prevent using the system boost

### DIFF
--- a/Appleseed/config.py
+++ b/Appleseed/config.py
@@ -54,6 +54,8 @@
 			" -D CMAKE_PREFIX_PATH={buildDir}"
 			" -D CMAKE_INSTALL_PREFIX={buildDir}/appleseed"
 			" -D CMAKE_LIBRARY_PATH={pythonLibDir}"
+			" -D BOOST_ROOT={buildDir}"
+			" -D Boost_NO_SYSTEM_PATHS=ON"
 			" ..",
 
 		"cd build && make install -j {jobs} VERBOSE=1"


### PR DESCRIPTION
It was grabbing the one out of the system, probably because it was a later version 1.73 in the aswf-docker...