### PR TITLE
Build: LLVM requires GCC_INSTALL_PREFIX set accurately

### DIFF
--- a/LLVM/config.py
+++ b/LLVM/config.py
@@ -18,6 +18,7 @@
 		"cd build &&"
 			" cmake"
 			" -DCMAKE_INSTALL_PREFIX={buildDir}"
+			" -DGCC_INSTALL_PREFIX=\"{compilerRoot}\""
 			" -DCMAKE_BUILD_TYPE=Release"
 			" -DLLVM_ENABLE_RTTI=ON"
 			" ..",

--- a/build.py
+++ b/build.py
@@ -405,6 +405,16 @@ def __buildPackage( projects, configs, buildDir, package ) :
 		for m in files :
 			file.add( os.path.join( buildDir, m ), arcname = os.path.join( rootName, m ) )
 
+def __getCompilerRoot():
+
+	# GCC 6.3.1 is located in /opt/rh/devtoolset-6/root for CentOS 7.
+
+	command = "which c++"
+	sys.stderr.write( command + "\n" )
+	output = subprocess.check_output( command, stderr=subprocess.STDOUT, shell = True, universal_newlines = True )
+	dirPath = os.path.dirname( os.path.realpath( output ) )
+	return dirPath.replace( "/bin", "" )
+
 parser = argparse.ArgumentParser()
 
 parser.add_argument(
@@ -464,6 +474,7 @@ variables = {
 	"platform" : "osx" if sys.platform == "darwin" else "linux",
 	"sharedLibraryExtension" : ".dylib" if sys.platform == "darwin" else ".so",
 	"c++Standard" : "14",
+	"compilerRoot" : __getCompilerRoot(),
 	"variants" : "".join( "-{}{}".format( key, variants[key] ) for key in sorted( variants.keys() ) ),
 }
 


### PR DESCRIPTION
CentOS 7 places GCC 6 and 9 in /opt/rh/devtoolset-X/root (oddly though that this has been compiling ok on devtoolset-6 and not devtoolset-9).

Addresses https://github.com/GafferHQ/dependencies/issues/193