### PR TITLE
OpenVDB: Prevent using the system boost

### DIFF
--- a/OpenVDB/config.py
+++ b/OpenVDB/config.py
@@ -33,6 +33,8 @@
 			" -D PYOPENVDB_INSTALL_DIRECTORY={buildDir}/python"
 			" -D Python_ROOT_DIR={buildDir}"
 			" -D Python_FIND_STRATEGY=LOCATION"
+			" -D BOOST_ROOT={buildDir}"
+			" -D Boost_NO_SYSTEM_PATHS=ON"
 			" .."
 		,
 


### PR DESCRIPTION
I was getting linker warnings that it linked to the system boost.