### PR TITLE
LLVM : Set GCC_INSTALL_PREFIX correctly

### DIFF
--- a/LLVM/config.py
+++ b/LLVM/config.py
@@ -18,6 +18,7 @@
 		"cd build &&"
 			" cmake"
 			" -DCMAKE_INSTALL_PREFIX={buildDir}"
+			" -DGCC_INSTALL_PREFIX={compilerRoot}"
 			" -DCMAKE_BUILD_TYPE=Release"
 			" -DLLVM_ENABLE_RTTI=ON"
 			" ..",

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import functools
@@ -81,6 +81,12 @@ permutations of the build.
 - variant:<ProjectName>:<VariantName> : Dictionary of overrides to apply
   based on the current variant of another project specified by `ProjectName`.
 """
+
+def __compilerRoot() :
+
+	compiler = shutil.which( "g++" )
+	binDir = os.path.dirname( compiler )
+	return os.path.dirname( binDir )
 
 def __projects() :
 
@@ -464,6 +470,7 @@ variables = {
 	"platform" : "osx" if sys.platform == "darwin" else "linux",
 	"sharedLibraryExtension" : ".dylib" if sys.platform == "darwin" else ".so",
 	"c++Standard" : "14",
+	"compilerRoot" : __compilerRoot(),
 	"variants" : "".join( "-{}{}".format( key, variants[key] ) for key in sorted( variants.keys() ) ),
 }
 


### PR DESCRIPTION
Otherwise we get problems finding C++ headers when OSL tries to compile with Clang. With thanks to boberfly for doing the hard work of figuring this out.

Also updated `build.py` to run via Python 3, so we can use `shutil.which()` instead of rolling our own. Python 2 is dead, and while we still need to support it in Gaffer itself for a bit longer, we can at least update our build toolchain.