### PR TITLE
Embree : Add version 3.13.3

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
 - Qt : Updated to version 5.15.2.
 - PySide : Updated to version 5.15.2.
 - Cortex : Updated to version 10.3.0.0.
+- Embree : Added version 3.13.3.
 
 3.1.0
 -----

--- a/Embree/config.py
+++ b/Embree/config.py
@@ -1,0 +1,44 @@
+{
+
+	"downloads" : [
+
+		"https://github.com/embree/embree/archive/v3.13.3.tar.gz"
+
+	],
+
+	"url" : "https://www.embree.org/",
+
+	"license" : "LICENSE.txt",
+
+	"dependencies" : [ "TBB" ],
+
+	"commands" : [
+
+		"mkdir gafferBuild",
+		"cd gafferBuild &&"
+			" cmake"
+			" -D CMAKE_INSTALL_PREFIX={buildDir}"
+			" -D CMAKE_PREFIX_PATH={buildDir}"
+			" -D CMAKE_INSTALL_LIBDIR={buildDir}/lib"
+			" -D EMBREE_TBB_ROOT={buildDir}"
+			" -D EMBREE_STATIC_LIB=OFF"
+			" -D EMBREE_ISPC_SUPPORT=OFF"
+			" -D EMBREE_TUTORIALS=OFF"
+			" -D EMBREE_RAY_MASK=ON"
+			" -D EMBREE_FILTER_FUNCTION=ON"
+			" -D EMBREE_BACKFACE_CULLING=OFF"
+			" -D EMBREE_TASKING_SYSTEM=TBB"
+			" ..",
+		"cd gafferBuild && make install -j {jobs} VERBOSE=1",
+
+	],
+
+	"manifest" : [
+
+		"include/embree3",
+
+		"lib/libembree3*{sharedLibraryExtension}*",
+
+	],
+
+}

--- a/TBB/config.py
+++ b/TBB/config.py
@@ -13,7 +13,9 @@
 	"commands" : [
 
 		"make -j {jobs} stdver=c++{c++Standard}",
+		"mkdir -p {buildDir}/include",
 		"cp -r include/tbb {buildDir}/include",
+		"mkdir -p {buildDir}/lib",
 		"{installLibsCommand}",
 
 	],

--- a/USD/config.py
+++ b/USD/config.py
@@ -10,7 +10,7 @@
 
 	"license" : "LICENSE.txt",
 
-	"dependencies" : [ "Boost", "Python", "OpenImageIO", "TBB", "Alembic", "OpenSubdiv", "OpenVDB", "PyOpenGL", "GLEW", "PySide" ],
+	"dependencies" : [ "Boost", "Python", "OpenImageIO", "TBB", "Alembic", "OpenSubdiv", "OpenVDB", "PyOpenGL", "GLEW", "PySide", "Embree" ],
 
 	"environment" : {
 
@@ -36,6 +36,7 @@
 			" -D PXR_ENABLE_PTEX_SUPPORT=FALSE"
 			" -D PXR_BUILD_TESTS=FALSE"
 			" -D PXR_BUILD_ALEMBIC_PLUGIN=TRUE"
+			" -D PXR_BUILD_EMBREE_PLUGIN=TRUE"
 			" -D PXR_ENABLE_HDF5_SUPPORT=FALSE"
 			" -D PXR_PYTHON_SHEBANG='/usr/bin/env python'"
 			" -D ALEMBIC_DIR={buildDir}/lib"


### PR DESCRIPTION
@boberfly, would be good if you could take a quick look at this. It's based on your config from GafferCycles, with a few changes :

- Removed build type vars and `cmake build` etc. I'm not against them in principle, but I'd rather add them for the whole repo at once at a later date. The time to think about this will be when we want to get this building on Windows too.
- Updated to 3.13.3 - just a patch version difference, so I think should be fine.
- Removed cmake options that were at the defaults anyway.
- Went for shared libraries, since I also want to enable HdEmbree. Let me know if this is a bad idea!