### PR TITLE
Package updates to facilitate GCC 11.2.1 (Rocky Linux 9/VFX platform 2023)

### DIFF
--- a/Cycles/patches/hydraUSDupdate.patch
+++ b/Cycles/patches/hydraUSDupdate.patch
@@ -1,0 +1,15 @@
+--- a/src/hydra/material.cpp
++++ b/src/hydra/material.cpp
+@@ -234,8 +234,12 @@ void HdCyclesMaterial::Sync(HdSceneDelegate *sceneDelegate,
+         _shader->tag_modified();
+       }
+       else {
++#if PXR_VERSION >= 2205
++        *networkConverted = HdConvertToHdMaterialNetwork2(networkOld);
++#else
+         networkConverted = std::make_unique<HdMaterialNetwork2>();
+         HdMaterialNetwork2ConvertFromHdMaterialNetworkMap(networkOld, networkConverted.get());
++#endif
+         network = networkConverted.get();
+       }
+     }

--- a/LLVM/config.py
+++ b/LLVM/config.py
@@ -2,8 +2,8 @@
 
 	"downloads" : [
 
-		"https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/llvm-11.1.0.src.tar.xz",
-		"https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/clang-11.1.0.src.tar.xz"
+		"https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/llvm-12.0.1.src.tar.xz",
+		"https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang-12.0.1.src.tar.xz"
 
 	],
 

--- a/Qt/config.py
+++ b/Qt/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://download.qt.io/official_releases/qt/5.15/5.15.4/single/qt-everywhere-opensource-src-5.15.4.tar.xz"
+		"https://download.qt.io/official_releases/qt/5.15/5.15.5/single/qt-everywhere-opensource-src-5.15.5.tar.xz"
 
 	],
 

--- a/USD/config.py
+++ b/USD/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/PixarAnimationStudios/USD/archive/refs/tags/v21.11.tar.gz"
+		"https://github.com/PixarAnimationStudios/USD/archive/refs/tags/v22.08.tar.gz"
 
 	],
 


### PR DESCRIPTION
Just getting in early, having fun with [distrobox](https://github.com/89luca89/distrobox)...

I also updated to Python 3.9.13 locally here but left it out of this PR as it should work on 3.7.x, however I noticed it links with libcrypt.so.2 (not to be confused with OpenSSL's libcrypto) which it shouldn't according to this https://bugs.python.org/issue45433 which causes Ubuntu to have issues when running there.

These fixes instead can be backported to our current versions as patches (mostly GCC is just complaining about missing `#include <limits>` when `std::numeric_limits` is used for all 3 packages). I have some of these already made if we prefer to do that.