### PR TITLE
Cycles : Update to version 3.4.0

### DIFF
--- a/Cycles/config.py
+++ b/Cycles/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/blender/cycles/archive/refs/tags/v3.2.0.tar.gz",
+		"https://github.com/blender/cycles/archive/refs/tags/v3.4.0.tar.gz",
 
 	],
 
@@ -10,7 +10,7 @@
 
 	"license" : "LICENSE",
 
-	"dependencies" : [ "Boost", "OpenJPEG", "OpenImageIO", "TBB", "Alembic", "Embree", "OpenColorIO", "OpenVDB", "OpenShadingLanguage", "USD" ],
+	"dependencies" : [ "Boost", "OpenJPEG", "OpenImageIO", "TBB", "Alembic", "Embree", "OpenColorIO", "OpenVDB", "OpenShadingLanguage", "USD", "Epoxy" ],
 
 	"commands" : [
 

--- a/Epoxy/config.py
+++ b/Epoxy/config.py
@@ -1,0 +1,30 @@
+{
+
+	"downloads" : [
+
+		"https://github.com/anholt/libepoxy/archive/refs/tags/1.5.10.tar.gz"
+
+	],
+
+	"url" : "https://github.com/anholt/libepoxy",
+	"license" : "COPYING",
+
+	"commands" : [
+
+		"meson gafferBuild/",
+		"meson configure gafferBuild/"
+		" -Dprefix={buildDir}"
+		" -Dtests=false",
+		"ninja -C gafferBuild/ install",
+		"mv {buildDir}/lib64/libepoxy* {buildDir}/lib/",
+
+	],
+
+	"manifest" : [
+
+		"include/epoxy",
+		"lib/libepoxy*{sharedLibraryExtension}*",
+
+	],
+
+}


### PR DESCRIPTION
- Updates Cycles to v3.4.0
- Needed to add libepoxy 1.5.10, this will require adding meson and ninja to the docker builder before merging