### PR TITLE
USD : Update to version 23.02

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+x.x.x (relative to 5.x.x)
+-----
+
+USD : Updated to version 23.02.
+
 5.x.x (relative to 5.1.0)
 -----
 

--- a/USD/config.py
+++ b/USD/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/PixarAnimationStudios/USD/archive/refs/tags/v21.11.tar.gz"
+		"https://github.com/PixarAnimationStudios/USD/archive/refs/tags/v23.02.tar.gz"
 
 	],
 
@@ -40,6 +40,8 @@
 			" -D PXR_BUILD_EMBREE_PLUGIN=TRUE"
 			" -D PXR_ENABLE_HDF5_SUPPORT=FALSE"
 			" -D PXR_PYTHON_SHEBANG='/usr/bin/env python'"
+			" -D Python3_ROOT_DIR={buildDir}"
+			" -D Python3_FIND_STRATEGY=LOCATION"
 			" -D ALEMBIC_DIR={buildDir}/lib"
 			" -D OPENEXR_LOCATION={buildDir}/lib"
 			# Needed to prevent CMake picking up system python libraries on Mac.


### PR DESCRIPTION
In particular Cinesite are keen to get their hands on this bugfix from 22.11 :

> Fixed usdc files to use read-only mappings in mmap mode to avoid commit charge on most of the file content, only changing page protections to read/write when detaching outstanding zero-copy-array data.

I've made this PR to `main` with the intention of cutting a 6.0.0 dependencies version for Gaffer 1.2.0.0. @ericmehl, hopefully updating the Windows dependencies to match doesn't pose too much of a problem?