### PR TITLE
Appleseed : Stop Mac build from finding system Python

### DIFF
--- a/Appleseed/config.py
+++ b/Appleseed/config.py
@@ -56,6 +56,7 @@
 			" -D CMAKE_LIBRARY_PATH={pythonLibDir}"
 			" -D BOOST_ROOT={buildDir}"
 			" -D Boost_NO_SYSTEM_PATHS=ON"
+			" {extraArguments}"
 			" ..",
 
 		"cd build && make install -j {jobs} VERBOSE=1"
@@ -106,6 +107,12 @@
 
 	],
 
+	"variables" : {
+
+		"extraArguments" : "",
+
+	},
+
 	"platform:linux" : {
 
 		"variables" : {
@@ -121,6 +128,8 @@
 		"variables" : {
 
 			"sseArguments" : "-D USE_SSE=OFF",
+			# Stop Mac build finding system Python library
+			"extraArguments" : "-D PYTHON3_LIBRARY={pythonLibDir}/libpython{pythonMajorVersion}{sharedLibraryExtension}"
 
 		},
 


### PR DESCRIPTION
Appleseed on MacOS was finding and using system Python. Setting `CMAKE_LIBRARY_PATH` and/or `CMAKE_FRAMEWORK_PATH` like we have done elsewhere didn't seem to give it the right hint, but setting `PYTHON3_LIBRARY` ensures it finds our Python instead.