### PR TITLE
Qt : Update Qt and PySide to 5.15.8

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,8 @@ x.x.x (relative to 6.x.x)
 - OpenColorIO : Updated to version 2.2.1.
 - OpenPGL : Added version 0.4.1.
 - PyBind11 : Updated to version 2.10.4.
+- PySide : Updated to version 5.15.8.
+- Qt : Updated to version 5.15.8.
 - Subprocess32 : Removed.
 - Six : Removed.
 - ZLib : Added version 1.2.13.

--- a/PySide/config.py
+++ b/PySide/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.4-src/pyside-setup-opensource-src-5.15.4.tar.xz"
+		"https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.8-src/pyside-setup-opensource-src-5.15.8.tar.xz"
 
 	],
 

--- a/Qt/config.py
+++ b/Qt/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://download.qt.io/official_releases/qt/5.15/5.15.4/single/qt-everywhere-opensource-src-5.15.4.tar.xz"
+		"https://download.qt.io/official_releases/qt/5.15/5.15.8/single/qt-everywhere-opensource-src-5.15.8.tar.xz"
 
 	],
 


### PR DESCRIPTION
Had some building problems with 5.15.4 on GCC 11.x