### PR TITLE
Imath : Improve installation of `imath` Python module

### DIFF
--- a/Imath/config.py
+++ b/Imath/config.py
@@ -34,14 +34,12 @@
 			" -D Python_ROOT_DIR={buildDir}"
 			" -D Python3_ROOT_DIR={buildDir}"
 			" -D Python3_FIND_STRATEGY=LOCATION"
+			" -D PYIMATH_OVERRIDE_PYTHON_INSTALL_DIR={buildDir}/python"
 			" ."
 		,
 
 		"make VERBOSE=1 -j {jobs}",
 		"make install",
-
-		"mkdir -p {buildDir}/python",
-		"mv {pythonLibDir}/python{pythonVersion}/site-packages/imath.so {buildDir}/python",
 
 	],
 


### PR DESCRIPTION
This puts it in the right place first time round, instead of putting it in the wrong place and then moving it. This fixes the build on MacOS, since the wrong place wasn't where we expected it to be.