### PR TITLE
OpenImageIO : Update to version 2.4.11.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+7.x.x (relative to 7.0.0a1)
+-----
+
+- OpenImageIO : Updated to version 2.4.11.0.
+
 7.0.0a1 (relative to 6.0.0)
 -------
 

--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.4.8.0.tar.gz"
+		"https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.4.11.0.tar.gz"
 
 	],
 


### PR DESCRIPTION
This gets us Eric's fix for the black-icon-problem on Windows.