### PR TITLE
Omit MaterialX resources

### DIFF
--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -74,6 +74,7 @@
 		"glsl/IECoreGL",
 		"glsl/*.frag",
 		"glsl/*.vert",
+		"resources/IECoreUSD/plugInfo.json",
 
 	],
 

--- a/GafferResources/config.py
+++ b/GafferResources/config.py
@@ -18,7 +18,13 @@
 
 	"manifest" : [
 
-		"resources",
+		"resources/hdri",
+		"resources/cow",
+		"resources/gafferBot",
+		# Can't include `resources/images` as a directory, because that
+		# catches a bunch of MaterialX stuff we don't want.
+		"resources/images/macaw.exr",
+		"resources/cortex",
 
 	],
 


### PR DESCRIPTION
Because these are hardcoded to install into a `resources` directory that we're already using for something else, this means tightening up the blanket inclusion of `resources` in the manifest, and instead just cherry-picking the bits we want.