### PR TITLE
MaterialX : Fix linking on MacOS

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+7.x.x (relative to 7.0.0)
+-----
+
+- MaterialX : Fixed linking on MacOS.
+
 7.0.0 (relative to 6.0.0)
 -----
 

--- a/MaterialX/patches/openImageIO.patch
+++ b/MaterialX/patches/openImageIO.patch
@@ -1,0 +1,13 @@
+--- a/source/MaterialXRender/External/OpenImageIO/FindOpenImageIO.cmake	2023-04-21 00:10:52.000000000 +0100
++++ b/source/MaterialXRender/External/OpenImageIO/FindOpenImageIO.cmake	2023-06-05 11:34:36.297457384 +0100
+@@ -47,0 +48,7 @@
++
++find_library ( OPENIMAGEIO_UTIL_LIBRARY
++               NAMES OpenImageIO_Util${OIIO_LIBNAME_SUFFIX}
++               HINTS ${OPENIMAGEIO_ROOT_DIR}/lib
++               PATH_SUFFIXES lib64 lib
++               PATHS "${OPENIMAGEIO_ROOT_DIR}/lib" )
++               
+@@ -69 +76 @@
+-set ( OPENIMAGEIO_LIBRARIES ${OPENIMAGEIO_LIBRARY})
++set ( OPENIMAGEIO_LIBRARIES ${OPENIMAGEIO_LIBRARY} ${OPENIMAGEIO_UTIL_LIBRARY})


### PR DESCRIPTION
Patch taken from https://github.com/AcademySoftwareFoundation/MaterialX/pull/1488