### PR TITLE
Build : Aswf-docker 2022 compatibility fixes WIP

### DIFF
--- a/Boost/config.py
+++ b/Boost/config.py
@@ -28,7 +28,7 @@
 	"commands" : [
 
 		"./bootstrap.sh --prefix={buildDir} --with-python={buildDir}/bin/python --with-python-root={buildDir} --without-libraries=log --without-icu",
-		"./b2 -d+2 -j {jobs} --disable-icu cxxflags='-std=c++{c++Standard}' cxxstd={c++Standard} variant=release link=shared threading=multi install",
+		"./b2 -d+2 -j {jobs} --disable-icu cxxflags='-std=c++{c++Standard}' cxxstd={c++Standard} variant=release link=shared threading=multi -s NO_LZMA=1 install",
 
 	],
 

--- a/LLVM/config.py
+++ b/LLVM/config.py
@@ -22,6 +22,7 @@
 			" -DCMAKE_BUILD_TYPE=Release"
 			" -DLLVM_ENABLE_RTTI=ON"
 			" -DLLVM_ENABLE_LIBXML2=OFF"
+			" -DLLVM_ENABLE_TERMINFO=OFF"
 			" ..",
 		"cd build && make install -j {jobs}"
 

--- a/LibWebP/config.py
+++ b/LibWebP/config.py
@@ -1,0 +1,28 @@
+{
+
+	"downloads" : [
+
+		"https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.3.2.tar.gz"
+
+	],
+
+	"url" : "https://chromium.googlesource.com/webm/libwebp",
+	"license" : "COPYING",
+
+	"commands" : [
+
+		"./configure --prefix={buildDir}",
+		"make -j {jobs}",
+		"make install",
+
+	],
+
+	"manifest" : [
+
+		"include/webp",
+		"lib/libwebp{sharedLibraryExtension}*",
+		"lib/libwebpdemux{sharedLibraryExtension}*",
+
+	],
+
+}

--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -30,6 +30,7 @@
 			" -D CMAKE_PREFIX_PATH={buildDir}"
 			" -D USE_FFMPEG=NO"
 			" -D USE_GIF=0"
+			" -D USE_PTEX=0"
 			" -D USE_WEBP=0"
 			" -D USE_PYTHON=YES"
 			" -D USE_EXTERNAL_PUGIXML=YES"

--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -10,7 +10,7 @@
 
 	"license" : "LICENSE.md",
 
-	"dependencies" : [ "Boost", "Python", "PyBind11", "OpenEXR", "LibTIFF", "LibPNG", "OpenJPEG", "LibJPEG-Turbo", "OpenColorIO", "LibRaw", "PugiXML", "Fmt" ],
+	"dependencies" : [ "Boost", "Python", "PyBind11", "OpenEXR", "LibTIFF", "LibPNG", "OpenJPEG", "LibJPEG-Turbo", "OpenColorIO", "LibRaw", "PugiXML", "Fmt", "LibWebP" ],
 
 	"environment" : {
 
@@ -31,7 +31,6 @@
 			" -D USE_FFMPEG=NO"
 			" -D USE_GIF=0"
 			" -D USE_PTEX=0"
-			" -D USE_WEBP=0"
 			" -D USE_PYTHON=YES"
 			" -D USE_EXTERNAL_PUGIXML=YES"
 			" -D BUILD_MISSING_FMT=NO"

--- a/OpenSubdiv/config.py
+++ b/OpenSubdiv/config.py
@@ -24,6 +24,7 @@
 			" -D NO_DX=1"
 			" -D NO_TESTS=1"
 			" -D NO_TBB=1"
+			" -D NO_PTEX=1"
 			" -D OPENEXR_LOCATION={buildDir}/lib"
 			" ."
 		,

--- a/Qt/config.py
+++ b/Qt/config.py
@@ -32,6 +32,7 @@
 			" -skip qt3d"
 			" -skip qtdeclarative"
 			" -skip qtwebchannel"
+			" -skip qtnetworkauth"
 			" -no-libudev"
 			" -no-icu"
 			" -qt-pcre"


### PR DESCRIPTION
Hi John, after you mentioned that you guys are looking into the aswf-dockers as a base, I tried building with 2022 (centos7 base) to see how far I could get before trying the 2023 one and had some fixes and workarounds here. I'll leave as a draft, feel free to just cherry-pick what makes sense.

So I built with 2022 but decided to run it in 2023 to see what breaks which seems like an effective way to find these problems with linking against the system libraries.

I used `ci-vfxall` but probably it is best to use `ci-common` so the existing libraries don't interfere with the ones that get built with Gaffer. Having said that I unset `/usr/local/lib:/usr/local/lib64` from `LD_LIBRARY_PATH` as well as unsetting `PYTHONPATH`.

- Boost : LZMA would link to an XZ library that had symbols specific to RHEL/Centos7 and would refuse to load in Rocky 8, disable it.

- LLVM : Ncurses must be installed in this image so it gets linked to libtinfo.so, as well as linking to anything using OSL. Disable it.

- OpenImageIO : Ptex gets detected and linked, disable it.

- OpenSubDiv : Ptex gets detected and the build fails (glLoader can't be found?) disable it.

- Qt : PySide2 seems to always want to build bindings for qtdeclarative (libQt5QML.so) so it was easier to just enable it. Probably would be preferred to build against ci-common.

The outstanding issues that this PR doesn't address and what I think the ci-common image would still have issues with is as follows:

- OpenImageIO : Unfortunately `libwebp.so.4` still gets detected so we either build our own or need to patch OIIO to not link with it when it is disabled.

- Qt : Kerberos gets linked from the image `libgssapi_krb5.so.2 , libk5crypto.so.3, libkrb5.so.3 , libkrb5support.so.0` via libQt5Network/libQt5NetworkAuth so I'm not sure if we just build our own and package it like OpenSSL or patch Qt to not link against it.