### PR TITLE
PsUtil : Add to `7_maintenance` branch

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 7.x.x (relative to 7.0.0)
 -----
 
+- Cortex : Updated to 10.5.4.2.
 - MaterialX : Fixed linking on MacOS.
 
 7.0.0 (relative to 6.0.0)

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 - Cortex : Updated to 10.5.4.2.
 - MaterialX : Fixed linking on MacOS.
+- PsUtil : Added version 5.9.6.
 
 7.0.0 (relative to 6.0.0)
 -----

--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -1,7 +1,7 @@
 {
 
 	"downloads" : [
-		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.5.0.0.tar.gz"
+		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.5.4.2.tar.gz"
 
 	],
 

--- a/PsUtil/config.py
+++ b/PsUtil/config.py
@@ -1,0 +1,35 @@
+{
+
+	"downloads" : [
+
+		"https://files.pythonhosted.org/packages/2d/01/beb7331fc6c8d1c49dd051e3611379bfe379e915c808e1301506027fce9d/psutil-5.9.6.tar.gz"
+
+	],
+
+	"url" : "https://github.com/giampaolo/psutil",
+
+	"license" : "LICENSE",
+
+	"dependencies" : [ "Python" ],
+
+	"environment" : {
+
+		"LD_LIBRARY_PATH" : "{buildDir}/lib",
+		"DYLD_FRAMEWORK_PATH" : "{buildDir}/lib",
+		"PYTHONPATH" : "{buildDir}/python",
+
+	},
+
+	"commands" : [
+
+		"{buildDir}/bin/python setup.py install --root / --prefix {buildDir}",
+
+	],
+
+	"manifest" : [
+
+		"lib/python{pythonVersion}/site-packages/psutil",
+
+	],
+
+}


### PR DESCRIPTION
We'll need this for our plan of dual builds of Gaffer 1.4, to get folks over the distro/abi hump.