### PR TITLE
Mac build fixes

### DIFF
--- a/OpenSubdiv/config.py
+++ b/OpenSubdiv/config.py
@@ -12,7 +12,8 @@
 
 	"commands" : [
 
-		"cmake"
+		"mkdir build",
+		"cd build && cmake"
 			" -D CMAKE_INSTALL_PREFIX={buildDir}"
 			" -D CMAKE_PREFIX_PATH={buildDir}"
 			" -D NO_DOC=1"
@@ -25,11 +26,10 @@
 			" -D NO_TESTS=1"
 			" -D NO_TBB=1"
 			" -D OPENEXR_LOCATION={buildDir}/lib"
-			" ."
+			" .."
 		,
 
-		"make VERBOSE=1 -j {jobs}",
-		"make install",
+		"cd build && make VERBOSE=1 -j {jobs} && make install",
 
 	],
 

--- a/Python/config.py
+++ b/Python/config.py
@@ -50,6 +50,7 @@
 	"variables" : {
 
 		"libraryType" : "--enable-shared",
+		"environmentCommand" : "",
 
 	},
 


### PR DESCRIPTION
A couple of minor fixes to get the latest round of dependencies updates building on macOS 12.5 with Xcode 13.4.1.