### PR TITLE
OpenEXR : Update to version 3.1.12

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,9 @@
 8.0.0 alpha x (relative to 8.0.0 alpha 6)
 -------------
 
+- Cortex : Updated to version 10.5.6.1.
+- OpenEXR : Updated to version 3.1.12.
+
 8.0.0 alpha 6 (relative to 8.0.0 alpha 5)
 -------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,8 @@
 
 - Cortex : Updated to version 10.5.6.1.
 - OpenEXR : Updated to version 3.1.12.
+- OpenImageIO : Updated to version 2.5.8.0.
+- OpenShadingLanguage : Updated to version 1.12.14.0.
 
 8.0.0 alpha 6 (relative to 8.0.0 alpha 5)
 -------------

--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -1,7 +1,8 @@
 {
 
 	"downloads" : [
-		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.5.6.0.tar.gz"
+
+		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.5.6.1.tar.gz"
 
 	],
 

--- a/OpenEXR/config.py
+++ b/OpenEXR/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.9.tar.gz"
+		"https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.12.tar.gz"
 
 	],
 

--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.4.17.0.tar.gz"
+		"https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.5.8.0.tar.gz"
 
 	],
 

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/archive/refs/tags/v1.12.9.0.tar.gz"
+		"https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/archive/refs/tags/v1.12.14.0.tar.gz"
 
 	],
 


### PR DESCRIPTION
Bumping up from 3.1.9 as there are bug fixes necessary for proper DWA compression support in ExrCore.

Cortex will require https://github.com/ImageEngine/cortex/pull/1407 in order to build with this version.