### PR TITLE
Python : Fix linking against openssl11

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 8.0.0 alpha x (relative to 8.0.0 alpha 7)
 -------------
 
-
+- Python : Fixed python binary unnecessarily linking against libssl in gcc9 builds.
 
 8.0.0 alpha 7 (relative to 8.0.0 alpha 6)
 -------------

--- a/Python/config.py
+++ b/Python/config.py
@@ -28,7 +28,7 @@
 
 	"commands" : [
 
-		"{environmentCommand} ./configure --prefix={buildDir} {libraryType} --enable-unicode=ucs4 --with-ensurepip=install --with-system-ffi",
+		"./configure --prefix={buildDir} {libraryType} --enable-unicode=ucs4 --with-ensurepip=install --with-system-ffi",
 		"make -j {jobs}",
 		"make install",
 
@@ -50,7 +50,6 @@
 	"variables" : {
 
 		"libraryType" : "--enable-shared",
-		"environmentCommand" : "",
 
 	},
 
@@ -59,17 +58,6 @@
 		( "{buildDir}/bin/python", "python3" ),
 
 	],
-
-	"platform:linux" : {
-
-		"variables" : {
-
-			# Needed to build Python with OpenSSL 1.1.1 support on Centos 7
-			"environmentCommand" : "CPPFLAGS=\"$(pkg-config --cflags openssl11)\" LDFLAGS=\"$(pkg-config --libs openssl11)\""
-
-		}
-
-	},
 
 	"platform:macos" : {
 


### PR DESCRIPTION
The approach taken in 9e3fdbc71e7b3b6a08ad993c82b11556fb2526df resulted in the `python` binary also linking against `libssl.so.1.1`, which then prevented Python from running on systems without it.

So we back out of that and instead adjust the build container in https://github.com/GafferHQ/build/pull/39 to allow `configure` to automatically find the openssl11 headers and libraries. This then leads to the `_ssl` and `_hashlib` modules linking against libssl.so.1.1, but the `python` binary untouched.