### PR TITLE
OpenEXR : Add DWA patches

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,9 @@
 8.0.0 alpha x (relative to 8.0.0 alpha 8)
 -------------
 
-
+- OpenEXR : Applied patches from the following pull requests :
+	- https://github.com/AcademySoftwareFoundation/openexr/pull/1591
+	- https://github.com/AcademySoftwareFoundation/openexr/pull/1684
 
 8.0.0 alpha 8 (relative to 8.0.0 alpha 7)
 -------------

--- a/OpenEXR/patches/pull-1591.patch
+++ b/OpenEXR/patches/pull-1591.patch
@@ -1,0 +1,12 @@
+diff --git a/src/lib/OpenEXRCore/internal_dwa_compressor.h b/src/lib/OpenEXRCore/internal_dwa_compressor.h
+index 03ad60669..219cc3f3e 100644
+--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
++++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
+@@ -1047,6 +1047,7 @@ DwaCompressor_uncompress (
+                 me->alloc_fn, me->free_fn, &(cd->_dctData), outBufferEnd);
+             if (rv != EXR_ERR_SUCCESS) return rv;
+ 
++            cd->_dctData._type = chan->data_type;
+             outBufferEnd += chan->width * chan->bytes_per_element;
+         }
+     }

--- a/OpenEXR/patches/pull-1684.patch
+++ b/OpenEXR/patches/pull-1684.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/OpenEXRCore/internal_dwa_compressor.h b/src/lib/OpenEXRCore/internal_dwa_compressor.h
+index 705a036c5..f96d22b37 100644
+--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
++++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
+@@ -1600,7 +1600,7 @@ DwaCompressor_classifyChannels (DwaCompressor* me)
+             prefixMap,
+             me->_numChannels,
+             curc->channel_name,
+-            (size_t) (curc->channel_name - suffix));
++            (size_t) (suffix - curc->channel_name));
+ 
+         for (size_t i = 0; i < me->_channelRuleCount; ++i)
+         {


### PR DESCRIPTION
It sounds like we'll be able to pick these up from an official OpenEXR 3.1.x release before too long, but I think it's worth applying them by hand in the meantime, so we can confirm that they do indeed fix the original problems reported in the wild. I'm aiming to get this into a new beta tomorrow @ericmehl, if you think that's doable?