### PR TITLE
OSL : include testshade binary

### DIFF
--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -54,6 +54,7 @@
 
 		"bin/oslc",
 		"bin/oslinfo",
+		"bin/testshade",
 		"include/OSL",
 		"lib/libosl*",
 		"lib/lib*oslexec*",


### PR DESCRIPTION
It would be quite useful to include the testshade binary to debug any issues with the version of OSL we ship.

I haven't tested this ( I have opened a conversation with IT about getting docker access so I can actually try out depedency builds ), but it seems pretty straightforward: OSL_BUILD_TESTS defaults on, and I don't see us turning it off, so I'm pretty sure we're building this binary, and just not deploying it.