### PR TITLE
Jemalloc : Enable `tls_model("initial-exec")`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+8.x.x (relative to 8.0.0)
+-----
+
+- Jemalloc : Enabled `tls_model("initial-exec")` to prevent infinite recursion with dynamic TLS on Linux distributions with modern glibc versions.
+
 8.0.0 (relative to 7.0.0)
 -----
 

--- a/Jemalloc/patches/tlsModel.patch
+++ b/Jemalloc/patches/tlsModel.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -5079,7 +5079,7 @@
+ main ()
+ {
+ static __thread int
+-               __attribute__((tls_model("initial-exec"))) foo;
++               __attribute__((tls_model("initial-exec"), unused)) foo;
+                foo = 0;
+   ;
+   return 0;


### PR DESCRIPTION
This avoids the potential of infinite recursion with dynamic TLS on modern glibc versions, as noted here: https://lists.gnu.org/archive/html/info-gnu/2024-01/msg00017.html

```
  The dynamic linker calls the malloc and free functions in more cases
  during TLS access if a shared object with dynamic TLS is loaded and
  unloaded.  This can result in an infinite recursion if a malloc
  replacement library or its dependencies use dynamic TLS instead of
  initial-exec TLS.
```

I'm not overly clear on the broader ramifications of this change without wider testing, but I've noticed other DCCs that ship Jemalloc 3.6.0 recently providing the same tls-model change for glibc 2.39 compatibility.

The patch is based on the below commit for Jemalloc 4.0.0, though `configure` is being patched instead of `configure.ac` as we call `configure` directly.

https://github.com/jemalloc/jemalloc/commit/f1cf3ea4753260d37c9a43463bae2140e00e16f0

This suggests that `initial-exec` was the intended default but the test has been long broken...