### PR TITLE
Qt : Fix a compile issue with PySide2 'DragMove'

### DIFF
--- a/Qt/patches/pyside2dragMoveFix.patch
+++ b/Qt/patches/pyside2dragMoveFix.patch
@@ -1,0 +1,132 @@
+--- a/qtbase/src/gui/kernel/qevent.h	2023-03-23 20:06:47.000000000 +0100
++++ b/qtbase/src/gui/kernel/qevent.h	2023-04-15 23:23:40.599956996 +0200
+@@ -104,15 +104,15 @@ protected:
+ class Q_GUI_EXPORT QMouseEvent : public QInputEvent
+ {
+ public:
+-    QMouseEvent(Type type, const QPointF &localPos, Qt::MouseButton button,
++    QMouseEvent(QEvent::Type type, const QPointF &localPos, Qt::MouseButton button,
+                 Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers);
+-    QMouseEvent(Type type, const QPointF &localPos, const QPointF &screenPos,
++    QMouseEvent(QEvent::Type type, const QPointF &localPos, const QPointF &screenPos,
+                 Qt::MouseButton button, Qt::MouseButtons buttons,
+                 Qt::KeyboardModifiers modifiers);
+-    QMouseEvent(Type type, const QPointF &localPos, const QPointF &windowPos, const QPointF &screenPos,
++    QMouseEvent(QEvent::Type type, const QPointF &localPos, const QPointF &windowPos, const QPointF &screenPos,
+                 Qt::MouseButton button, Qt::MouseButtons buttons,
+                 Qt::KeyboardModifiers modifiers);
+-    QMouseEvent(Type type, const QPointF &localPos, const QPointF &windowPos, const QPointF &screenPos,
++    QMouseEvent(QEvent::Type type, const QPointF &localPos, const QPointF &windowPos, const QPointF &screenPos,
+                 Qt::MouseButton button, Qt::MouseButtons buttons,
+                 Qt::KeyboardModifiers modifiers, Qt::MouseEventSource source);
+     ~QMouseEvent();
+@@ -154,7 +154,7 @@ protected:
+ class Q_GUI_EXPORT QHoverEvent : public QInputEvent
+ {
+ public:
+-    QHoverEvent(Type type, const QPointF &pos, const QPointF &oldPos, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
++    QHoverEvent(QEvent::Type type, const QPointF &pos, const QPointF &oldPos, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
+     ~QHoverEvent();
+ 
+ #ifndef QT_NO_INTEGER_EVENT_COORDINATES
+@@ -282,12 +282,12 @@ public:
+ #if QT_DEPRECATED_SINCE(5, 15)
+     // Actually deprecated since 5.4, in docs
+     QT_DEPRECATED_VERSION_X_5_15("Use the other QTabletEvent constructor")
+-    QTabletEvent(Type t, const QPointF &pos, const QPointF &globalPos,
++    QTabletEvent(QEvent::Type t, const QPointF &pos, const QPointF &globalPos,
+                  int device, int pointerType, qreal pressure, int xTilt, int yTilt,
+                  qreal tangentialPressure, qreal rotation, int z,
+                  Qt::KeyboardModifiers keyState, qint64 uniqueID); // ### remove in Qt 6
+ #endif
+-    QTabletEvent(Type t, const QPointF &pos, const QPointF &globalPos,
++    QTabletEvent(QEvent::Type t, const QPointF &pos, const QPointF &globalPos,
+                  int device, int pointerType, qreal pressure, int xTilt, int yTilt,
+                  qreal tangentialPressure, qreal rotation, int z,
+                  Qt::KeyboardModifiers keyState, qint64 uniqueID,
+@@ -377,9 +377,9 @@ protected:
+ class Q_GUI_EXPORT QKeyEvent : public QInputEvent
+ {
+ public:
+-    QKeyEvent(Type type, int key, Qt::KeyboardModifiers modifiers, const QString& text = QString(),
++    QKeyEvent(QEvent::Type type, int key, Qt::KeyboardModifiers modifiers, const QString& text = QString(),
+               bool autorep = false, ushort count = 1);
+-    QKeyEvent(Type type, int key, Qt::KeyboardModifiers modifiers,
++    QKeyEvent(QEvent::Type type, int key, Qt::KeyboardModifiers modifiers,
+               quint32 nativeScanCode, quint32 nativeVirtualKey, quint32 nativeModifiers,
+               const QString &text = QString(), bool autorep = false, ushort count = 1);
+     ~QKeyEvent();
+@@ -399,7 +399,7 @@ public:
+ 
+     // Functions for the extended key event information
+ #if QT_DEPRECATED_SINCE(5, 0)
+-    static inline QKeyEvent *createExtendedKeyEvent(Type type, int key, Qt::KeyboardModifiers modifiers,
++    static inline QKeyEvent *createExtendedKeyEvent(QEvent::Type type, int key, Qt::KeyboardModifiers modifiers,
+                                              quint32 nativeScanCode, quint32 nativeVirtualKey,
+                                              quint32 nativeModifiers,
+                                              const QString& text = QString(), bool autorep = false,
+@@ -682,7 +682,7 @@ class Q_GUI_EXPORT QDragMoveEvent : publ
+ {
+ public:
+     QDragMoveEvent(const QPoint &pos, Qt::DropActions actions, const QMimeData *data,
+-                   Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, Type type = DragMove);
++                   Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, QEvent::Type type = QEvent::DragMove);
+     ~QDragMoveEvent();
+ 
+     inline QRect answerRect() const { return rect; }
+--- a/qtbase/src/widgets/graphicsview/qgraphicssceneevent.h	2023-03-23 20:06:47.000000000 +0100
++++ b/qtbase/src/widgets/graphicsview/qgraphicssceneevent.h	2023-04-15 23:22:38.038387091 +0200
+@@ -82,7 +82,7 @@ class QGraphicsSceneMouseEventPrivate;
+ class Q_WIDGETS_EXPORT QGraphicsSceneMouseEvent : public QGraphicsSceneEvent
+ {
+ public:
+-    explicit QGraphicsSceneMouseEvent(Type type = None);
++    explicit QGraphicsSceneMouseEvent(QEvent::Type type = QEvent::None);
+     ~QGraphicsSceneMouseEvent();
+ 
+     QPointF pos() const;
+@@ -136,7 +136,7 @@ class QGraphicsSceneWheelEventPrivate;
+ class Q_WIDGETS_EXPORT QGraphicsSceneWheelEvent : public QGraphicsSceneEvent
+ {
+ public:
+-    explicit QGraphicsSceneWheelEvent(Type type = None);
++    explicit QGraphicsSceneWheelEvent(QEvent::Type type = QEvent::None);
+     ~QGraphicsSceneWheelEvent();
+ 
+     QPointF pos() const;
+@@ -171,7 +171,7 @@ class Q_WIDGETS_EXPORT QGraphicsSceneCon
+ public:
+     enum Reason { Mouse, Keyboard, Other };
+ 
+-    explicit QGraphicsSceneContextMenuEvent(Type type = None);
++    explicit QGraphicsSceneContextMenuEvent(QEvent::Type type = QEvent::None);
+     ~QGraphicsSceneContextMenuEvent();
+ 
+     QPointF pos() const;
+@@ -198,7 +198,7 @@ class QGraphicsSceneHoverEventPrivate;
+ class Q_WIDGETS_EXPORT QGraphicsSceneHoverEvent : public QGraphicsSceneEvent
+ {
+ public:
+-    explicit QGraphicsSceneHoverEvent(Type type = None);
++    explicit QGraphicsSceneHoverEvent(QEvent::Type type = QEvent::None);
+     ~QGraphicsSceneHoverEvent();
+ 
+     QPointF pos() const;
+@@ -231,7 +231,7 @@ class QGraphicsSceneHelpEventPrivate;
+ class Q_WIDGETS_EXPORT QGraphicsSceneHelpEvent : public QGraphicsSceneEvent
+ {
+ public:
+-    explicit QGraphicsSceneHelpEvent(Type type = None);
++    explicit QGraphicsSceneHelpEvent(QEvent::Type type = QEvent::None);
+     ~QGraphicsSceneHelpEvent();
+ 
+     QPointF scenePos() const;
+@@ -249,7 +249,7 @@ class QGraphicsSceneDragDropEventPrivate
+ class Q_WIDGETS_EXPORT QGraphicsSceneDragDropEvent : public QGraphicsSceneEvent
+ {
+ public:
+-    explicit QGraphicsSceneDragDropEvent(Type type = None);
++    explicit QGraphicsSceneDragDropEvent(QEvent::Type type = QEvent::None);
+     ~QGraphicsSceneDragDropEvent();
+ 
+     QPointF pos() const;


### PR DESCRIPTION
This is building in aswf-common same as gafferhq, so I am not too sure why this hasn't been hit sooner.

Issue details:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=270715

Patch derived from:
https://github.com/OpenMandrivaAssociation/qt5-qtbase/blob/master/qtbase-5.15.9-work-around-pyside2-brokenness.patch