### PR TITLE
Prep for dependencies 9.0.0 alpha 2

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 9.0.0 alpha x (relative to 9.0.0 alpha 1)
 -------------
 
+- Cortex : Updated to version 10.5.9.2.
 - Zstandard : Fixed manifest path on macOS.
 
 9.0.0 alpha 1 (relative to 8.0.1)

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+9.0.0 alpha x (relative to 9.0.0 alpha 1)
+-------------
+
+- Zstandard : Fixed manifest path on macOS.
+
 9.0.0 alpha 1 (relative to 8.0.1)
 -------------
 

--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.5.9.1.tar.gz"
+		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.5.9.2.tar.gz"
 
 	],
 

--- a/Zstandard/config.py
+++ b/Zstandard/config.py
@@ -30,7 +30,7 @@
 	"manifest" : [
 
 		"include/zstd.h",
-		"lib/libzstd{sharedLibraryExtension}*"
+		"lib/libzstd*{sharedLibraryExtension}*"
 
 	],
 


### PR DESCRIPTION
Bump Cortex and fix Zstandard manifest on macOS for the next alpha release.