### PR TITLE
OpenShadingLanguage : Update to version 1.13.11.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           - name: linux-gcc11
             os: ubuntu-20.04
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:3.0.0
+            containerImage: ghcr.io/gafferhq/build/build:3.1.0
             jobs: 4
 
           - name: macos-arm64

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,9 @@
 9.0.0 alpha x (relative to 9.0.0 alpha 3)
 -------------
 
-- OpenShadingLanguage : Updated to version 1.13.11.0.
+- OpenShadingLanguage :
+  - Updated to version 1.13.11.0.
+  - Enabled Optix support on Linux.
 
 9.0.0 alpha 3 (relative to 9.0.0 alpha 2)
 -------------

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 9.0.0 alpha x (relative to 9.0.0 alpha 3)
 -------------
 
-
+- OpenShadingLanguage : Updated to version 1.13.11.0.
 
 9.0.0 alpha 3 (relative to 9.0.0 alpha 2)
 -------------

--- a/LLVM/config.py
+++ b/LLVM/config.py
@@ -27,10 +27,26 @@
 			" -DLLVM_ENABLE_ZSTD=OFF"
 			" -DLLVM_INCLUDE_BENCHMARKS=OFF"
 			" -DLLVM_INCLUDE_TESTS=OFF"
-			" -DLLVM_TARGETS_TO_BUILD='Native'"
+			" -DLLVM_TARGETS_TO_BUILD={buildTargets}"
 			" ..",
 		"cd build && make install -j {jobs}"
 
 	],
+
+	"variables" : {
+
+		"buildTargets" : "'Native'",
+
+	},
+
+	"platform:linux" : {
+
+		"variables" : {
+
+			"buildTargets" : "'Native;NVPTX'",
+
+		},
+
+	},
 
 }

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -19,6 +19,9 @@
 		"DYLD_FALLBACK_LIBRARY_PATH" : "{buildDir}/lib",
 		"LD_LIBRARY_PATH" : "{buildDir}/lib",
 		"PATH" : "{buildDir}/bin:$PATH",
+		# We define `OPTIX_ROOT_DIR` in the build container for
+		# Cycles to find it, but OSL wants `OPTIX_INSTALL_DIR`.
+		"OPTIX_INSTALL_DIR" : "$OPTIX_ROOT_DIR",
 
 	},
 
@@ -37,6 +40,7 @@
 			" -D OSL_SHADER_INSTALL_DIR={buildDir}/shaders"
 			" -D Python_ROOT_DIR={buildDir}"
 			" -D Python_FIND_STRATEGY=LOCATION"
+			" {extraArguments}"
 			" ..",
 		"cd gafferBuild && make install -j {jobs} VERBOSE=1",
 		"cp {buildDir}/share/doc/OSL/osl-languagespec.pdf {buildDir}/doc",
@@ -46,6 +50,7 @@
 
 	"variables" : {
 
+		"extraArguments" : "",
 		"extraCommands" : "",
 		"useBatched" : "b8_AVX,b8_AVX2,b8_AVX2_noFMA,b8_AVX512,b8_AVX512_noFMA,b16_AVX512,b16_AVX512_noFMA",
 
@@ -64,6 +69,15 @@
 		"shaders",
 
 	],
+
+	"platform:linux" : {
+
+		"variables" : {
+
+			"extraArguments" : "-D OSL_USE_OPTIX=1",
+
+		},
+	},
 
 	"platform:macos" : {
 

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/archive/refs/tags/v1.12.14.0.tar.gz"
+		"https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/archive/refs/tags/v1.13.11.0.tar.gz"
 
 	],
 
@@ -32,7 +32,6 @@
 			" -D CMAKE_INSTALL_LIBDIR={buildDir}/lib"
 			" -D CMAKE_PREFIX_PATH={buildDir}"
 			" -D STOP_ON_WARNING=0"
-			" -D ENABLERTTI=1"
 			" -D LLVM_STATIC=1"
 			" -D USE_BATCHED={useBatched}"
 			" -D OSL_SHADER_INSTALL_DIR={buildDir}/shaders"


### PR DESCRIPTION
Update to OSL 1.13.11.0 and build with Optix support on Linux, which requires the new `3.1.0` build container.