### PR TITLE
Boost : Change to new download location

### DIFF
--- a/Boost/config.py
+++ b/Boost/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz"
+		"https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz"
 
 	],
 


### PR DESCRIPTION
Due to an increase in traffic, JFrog is no longer hosting Boost releases. https://archives.boost.io is their new home as of the start of the year.

https://lists.boost.org/Archives/boost/2024/05/256914.php