### PR TITLE
Initial VFX Platform 2024 updates

### DIFF
--- a/Boost/patches/enum.patch
+++ b/Boost/patches/enum.patch
@@ -1,0 +1,10 @@
+--- a/libs/python/src/object/enum.cpp	2025-05-13 11:34:50.838894911 -0700
++++ b/libs/python/src/object/enum.cpp	2025-05-13 11:35:07.317490405 -0700
+@@ -113,7 +113,6 @@
+ #if PY_VERSION_HEX < 0x03000000
+     | Py_TPFLAGS_CHECKTYPES
+ #endif
+-    | Py_TPFLAGS_HAVE_GC
+     | Py_TPFLAGS_BASETYPE,                  /* tp_flags */
+     0,                                      /* tp_doc */
+     0,                                      /* tp_traverse */

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
 - OpenColorIO : Updated to version 2.3.2.
 - OpenEXR : Updated to version 3.2.4.
 - OpenSubdiv : Updated to version 3.6.0.
+- OpenVDB : Updated to version 11.0.0.
 - USD : Updated to version 25.05.
 
 9.1.0 (relative to 9.0.0)

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 - Cortex : Updated to version 10.5.13.1.
 - Minizip : Updated to version 3.0.10.
 - OpenColorIO : Updated to version 2.3.2.
+- OpenEXR : Updated to version 3.2.4.
 - USD : Updated to version 25.05.
 
 9.1.0 (relative to 9.0.0)

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,8 @@
 - OpenSubdiv : Updated to version 3.6.0.
 - OpenVDB : Updated to version 11.0.0.
 - Python : Updated to version 3.11.12.
+- PySide : Updated to version 5.15.16.
+- Qt : Updated to version 5.15.16.
 - USD : Updated to version 25.05.
 
 9.1.0 (relative to 9.0.0)

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@
 - OpenEXR : Updated to version 3.2.4.
 - OpenSubdiv : Updated to version 3.6.0.
 - OpenVDB : Updated to version 11.0.0.
+- Python : Updated to version 3.11.12.
 - USD : Updated to version 25.05.
 
 9.1.0 (relative to 9.0.0)

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 - Minizip : Updated to version 3.0.10.
 - OpenColorIO : Updated to version 2.3.2.
 - OpenEXR : Updated to version 3.2.4.
+- OpenSubdiv : Updated to version 3.6.0.
 - USD : Updated to version 25.05.
 
 9.1.0 (relative to 9.0.0)

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,8 @@
 ------
 
 - Cortex : Updated to version 10.5.13.1.
+- Minizip : Updated to version 3.0.10.
+- OpenColorIO : Updated to version 2.3.2.
 - USD : Updated to version 25.05.
 
 9.1.0 (relative to 9.0.0)

--- a/Minizip/config.py
+++ b/Minizip/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/zlib-ng/minizip-ng/archive/refs/tags/3.0.9.tar.gz",
+		"https://github.com/zlib-ng/minizip-ng/archive/refs/tags/3.0.10.tar.gz",
 
 	],
 

--- a/Minizip/patches/version.patch
+++ b/Minizip/patches/version.patch
@@ -1,0 +1,11 @@
+--- a/mz.h	2025-05-13 09:53:18.702514054 -0700
++++ b/mz.h	2025-05-13 09:53:29.271092945 -0700
+@@ -15,7 +15,7 @@
+
+ /* MZ_VERSION */
+ #define MZ_VERSION                      ("3.0.10")
+-#define MZ_VERSION_BUILD                (03000a)
++#define MZ_VERSION_BUILD                (030010)
+
+ /* MZ_ERROR */
+ #define MZ_OK                           (0)  /* zlib */

--- a/OpenColorIO/config.py
+++ b/OpenColorIO/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v2.2.1.tar.gz",
+		"https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v2.3.2.tar.gz",
 		"https://github.com/imageworks/OpenColorIO-Configs/archive/v1.0_r2.tar.gz",
 
 	],
@@ -30,7 +30,7 @@
 			" -D CMAKE_PREFIX_PATH={buildDir}"
 			" -D Python_ROOT_DIR={buildDir}"
 			" -D Python_FIND_STRATEGY=LOCATION"
-			" -D pystring_INCLUDE_DIR={buildDir}/include"
+			" -D pystring_INCLUDE_DIR={buildDir}/include/pystring"
 			" -D BUILD_SHARED_LIBS=ON"
 			" -D OCIO_INSTALL_EXT_PACKAGES=NONE"
 			" -D OCIO_BUILD_APPS=OFF"

--- a/OpenEXR/config.py
+++ b/OpenEXR/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.13.tar.gz"
+		"https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.2.4.tar.gz"
 
 	],
 

--- a/OpenSubdiv/config.py
+++ b/OpenSubdiv/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v3_5_1.tar.gz"
+		"https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v3_6_0.tar.gz"
 
 	],
 

--- a/OpenVDB/config.py
+++ b/OpenVDB/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v10.1.0.tar.gz"
+		"https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v11.0.0.tar.gz"
 
 	],
 

--- a/PySide/config.py
+++ b/PySide/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.14-src/pyside-setup-opensource-src-5.15.14.tar.xz"
+		"https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.16-src/pyside-setup-opensource-src-5.15.16.tar.xz"
 
 	],
 

--- a/Python/config.py
+++ b/Python/config.py
@@ -1,12 +1,12 @@
 {
 
-	"downloads" : [ "https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz" ],
+	"downloads" : [ "https://www.python.org/ftp/python/3.11.12/Python-3.11.12.tgz" ],
 
 	"publicVariables" : {
 
-		"pythonVersion" : "3.10",
+		"pythonVersion" : "3.11",
 		"pythonMajorVersion" : "3",
-		"pythonMinorVersion" : "10",
+		"pythonMinorVersion" : "11",
 		"pythonIncludeDir" : "{buildDir}/include/python{pythonVersion}",
 		"pythonLibDir" : "{buildDir}/lib",
 

--- a/Qt/config.py
+++ b/Qt/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://download.qt.io/official_releases/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+		"https://download.qt.io/official_releases/qt/5.15/5.15.16/single/qt-everywhere-opensource-src-5.15.16.tar.xz"
 
 	],
 


### PR DESCRIPTION
This begins bumping our dependency versions to better align with VFX Platform 2024. 

Notably, Boost hasn't been updated here as we'll first require some of the updates from https://github.com/ImageEngine/cortex/pull/1460 merged and a new Cortex version released. For now, I've included a small patch to fix an issue between Boost 1.80 and Python 3.11, but this can be dropped as soon as we update to Boost 1.82.

We expect the Qt 6.5 update will be tackled independently after the remainder of the dependencies updates are in place. In the meantime I've bumped Qt 5.15 to the latest available as this includes some fixes that should help us restore macOS CI with Xcode 15.