### PR TITLE
Qt/PySide : Update to version 6.5.6

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,8 +1,8 @@
 10.0.0 alpha x (relative to 10.0.0 alpha 1)
 --------------
 
-- PySide : Updated to version 6.5.5.
-- Qt : Updated to version 6.5.5.
+- PySide : Updated to version 6.5.6.
+- Qt : Updated to version 6.5.6.
 - Qt.py : Updated to version 1.4.6.
 
 10.0.0 alpha 1 (relative to 9.1.0)

--- a/PySide/config.py
+++ b/PySide/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.5.5-src/pyside-setup-opensource-src-6.5.5.tar.xz"
+		"https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.5.6-src/pyside-setup-opensource-src-6.5.6.tar.xz"
 
 	],
 

--- a/Qt/config.py
+++ b/Qt/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://download.qt.io/official_releases/qt/6.5/6.5.5/src/single/qt-everywhere-opensource-src-6.5.5.tar.xz"
+		"https://download.qt.io/official_releases/qt/6.5/6.5.6/src/single/qt-everywhere-opensource-src-6.5.6.tar.xz"
 
 	],
 


### PR DESCRIPTION
This recent Qt open source release appears to fix a few of the overly-zealous QTreeView/QTableView column resizing issues we've run into with Qt 6.5.5. I've yet to find a public changelog for 6.5.6 so I can't point at specific bugfix(es), but local testing on Linux shows behaviour similar to what we'd expect from Qt 5.15.

I'm making this PR to `10_maintenance` to keep it separate from the recent updates to `main` while we decide on the contents of `10.0.0a2`.