### PR TITLE
OpenShadingLanguage : Don't build `osl.imageio` plugin

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 10.0.0 alpha x (relative to 10.0.0 alpha 5)
 --------------
 
-
+- OpenShadingLanguage : Removed `osl.imageio` OpenImageIO format plugin.
 
 10.0.0 alpha 5 (relative to 10.0.0 alpha 4)
 --------------

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -38,6 +38,7 @@
 			" -D LLVM_STATIC=1"
 			" -D USE_BATCHED={useBatched}"
 			" -D OSL_SHADER_INSTALL_DIR={buildDir}/shaders"
+			" -D OSL_BUILD_PLUGINS=0"
 			" -D Python_ROOT_DIR={buildDir}"
 			" -D Python_FIND_STRATEGY=LOCATION"
 			" {extraArguments}"
@@ -63,7 +64,6 @@
 		"include/OSL",
 		"lib/libosl*",
 		"lib/lib*oslexec*",
-		"lib/osl.imageio.*",
 		"doc/osl*",
 		"shaders",
 


### PR DESCRIPTION
This implements a "virtual" texture file by evaluating an OSL shading network, and way back in f1d828f02ab2e0bbf080271df96c94bb8d28bc05 we added it to the package because we said "we'd like to have a little play with it". Since then I don't think we've done anything with it at all, so it doesn't have a strong case for inclusion.

The reason this has come up is that I've just discovered that OpenImageIO loads all plugins with `RTLD_GLOBAL`, polluting the global symbol table with all sorts of stuff - OSL, Boost, OpenEXR, OpenColorIO etc etc. It turned out this was actually masking a linking problem with Gaffer's Arnold plugin, which became apparent due to https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4245, which meant that the `osl.imageio` plugin was no longer being loaded in Gaffer 1.6 anyway, and we got crashes in Arnold renders as a result.

We _could_ fix the Arnold crash by making sure that `osl.imageio` continues to load in Gaffer 1.6, but given the RTLD_GLOBAL issue, I'd rather strip things back to a clean slate and fix things properly.