### PR TITLE
Post `commands` copy / move files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
             jobs: 4
             containerImage:
             # Something simple to start. When ready, the projects below should be included in the first job.
-            projectsString: --projects GafferResources
+            projectsString: --projects GafferResources BitstreamVera
             # projectsString: --projects LibFFI TBB Python ZLib Boost Imath OpenEXR HDF5 Alembic BitstreamVera Blosc CMark PyBind11 LibJPEG-Turbo LibTIFF LibPNG OpenJPEG Expat YAML-CPP PyString Minizip OpenColorIO LibRaw PugiXML Fmt LibWebP FreeType OpenImageIO LLVM OpenShadingLanguage GLEW OpenVDB OpenSubdiv PyOpenGL Qt PySide
 
     uses: ./.github/workflows/buildDependencyBatch.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
             jobs: 4
             containerImage:
             # Something simple to start. When ready, the projects below should be included in the first job.
-            projectsString: --projects GafferResources BitstreamVera
+            projectsString: --projects GafferResources BitstreamVera PCG
             # projectsString: --projects LibFFI TBB Python ZLib Boost Imath OpenEXR HDF5 Alembic BitstreamVera Blosc CMark PyBind11 LibJPEG-Turbo LibTIFF LibPNG OpenJPEG Expat YAML-CPP PyString Minizip OpenColorIO LibRaw PugiXML Fmt LibWebP FreeType OpenImageIO LLVM OpenShadingLanguage GLEW OpenVDB OpenSubdiv PyOpenGL Qt PySide
 
     uses: ./.github/workflows/buildDependencyBatch.yml

--- a/BitstreamVera/config.py
+++ b/BitstreamVera/config.py
@@ -10,10 +10,11 @@
 
 	"license" : "COPYRIGHT.TXT",
 
-	"commands" : [
+	"commands" : [],
 
-		"mkdir -p {buildDir}/fonts",
-		"cp *.ttf {buildDir}/fonts"
+	"postBuildCopy" : [
+
+		( None, "*.ttf", "{buildDir}/fonts" ),
 
 	],
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 11.x.x (relative to 11.0.0a4)
 ------
 
+- build.py : Added `postBuildCopy` and `postBuildMove` configuration steps.
 
 
 11.0.0a4 (relative to 11.0.0a3)

--- a/Cycles/config.py
+++ b/Cycles/config.py
@@ -40,13 +40,20 @@
 			" ..",
 		"cd build && make install -j {jobs} VERBOSE=1",
 
-		"mkdir -p {buildDir}/cycles/include",
-		"cd src && find . -name '*.h' | cpio -pdm {buildDir}/cycles/include",
-		"cp -r third_party/atomic/* {buildDir}/cycles/include",
-		"mkdir -p {buildDir}/cycles/bin",
-		"mv {buildDir}/cycles/cycles {buildDir}/cycles/bin/cycles",
-		"cp -r build/lib {buildDir}/cycles",
+	],
 
+	"postBuildCopy" : [
+
+		( "src", "**/*.h", "{buildDir}/cycles/include" ),
+		( "third_party/atomic", "**/*.h", "{buildDir}/cycles/include" ),
+		( "build/lib", "**/*", "{buildDir}/cycles/lib" ),
+
+	],
+    
+	"postBuildMove" : [
+        
+		( "{buildDir}/cycles", "cycles", "{buildDir}/cycles/bin" ),
+        
 	],
 
 	"manifest" : [

--- a/OpenColorIO/config.py
+++ b/OpenColorIO/config.py
@@ -43,12 +43,19 @@
 
 		"cd build && make clean && make VERBOSE=1 -j {jobs} && make install",
 
-		"mkdir -p {buildDir}/python",
-		"mv {buildDir}/lib*/python*/site-packages/PyOpenColorIO* {buildDir}/python",
+	],
 
-		"mkdir -p {buildDir}/openColorIO",
-		"cp ../studio-config-v3.0.0_aces-v2.0_ocio-v2.4.ocio {buildDir}/openColorIO",
-		"cp ../cg-config-v3.0.0_aces-v2.0_ocio-v2.4.ocio {buildDir}/openColorIO",
+	"postBuildCopy" : [
+
+
+		( "..", "studio-config-v3.0.0_aces-v2.0_ocio-v2.4.ocio", "{buildDir}/openColorIO" ),
+		( "..", "cg-config-v3.0.0_aces-v2.0_ocio-v2.4.ocio", "{buildDir}/openColorIO" ),
+
+	],
+
+	"postBuildMove" : [
+
+        ( "{buildDir}/lib/python{pythonVersion}/site-packages", "PyOpenColorIO*/**/*", "{buildDir}/python" ),
 
 	],
 

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -45,14 +45,12 @@
 			" {extraArguments}"
 			" ..",
 		"cd gafferBuild && make install -j {jobs} VERBOSE=1",
-		"{extraCommands}",
 
 	],
 
 	"variables" : {
 
 		"extraArguments" : "",
-		"extraCommands" : "",
 		"useBatched" : "b8_AVX,b8_AVX2,b8_AVX2_noFMA,b8_AVX512,b8_AVX512_noFMA,b16_AVX512,b16_AVX512_noFMA",
 
 	},
@@ -81,9 +79,14 @@
 
 	"platform:macos" : {
 
+		"postBuildMove" : [
+
+			( "{buildDir}/lib/python{pythonVersion}/site-packages", "oslquery", "{pythonLibDir}/python{pythonVersion}/site-packages" ),
+
+		],
+
 		"variables" : {
 
-			"extraCommands" : "mv {buildDir}/lib/python{pythonVersion}/site-packages/oslquery {pythonLibDir}/python{pythonVersion}/site-packages/oslquery",
 			"useBatched" : "0",
 
 		},

--- a/PCG/config.py
+++ b/PCG/config.py
@@ -10,10 +10,11 @@
 
 	"license" : "LICENSE-MIT.txt",
 
+	"commands" : [],
 
-	"commands" : [
-		"mkdir -p {buildDir}/include/pcg",
-		"cp include/*.hpp {buildDir}/include/pcg",
+	"postBuildCopy" : [
+
+		( "include", "*.hpp", "{buildDir}/include/pcg" ),
 
 	],
 

--- a/PyString/config.py
+++ b/PyString/config.py
@@ -20,7 +20,12 @@
 			" -D BUILD_SHARED_LIBS=ON"
 			" ..",
 		"cd build && make -j {jobs} && make install",
-		"mkdir -p {buildDir}/include/pystring && cp pystring.h {buildDir}/include/pystring",
+
+	],
+
+	"postBuildCopy" : [
+
+		( None, "pystring.h", "{buildDir}/include/pystring" ),
 
 	],
 

--- a/Qt.py/config.py
+++ b/Qt.py/config.py
@@ -11,9 +11,11 @@
 
 	"dependencies" : [ "Python" ],
 
-	"commands" : [
+	"commands" : [],
 
-		"cp Qt.py {buildDir}/python",
+	"postBuildCopy" : [
+
+		( None, "Qt.py", "{buildDir}/python" )
 
 	],
 

--- a/Qt/config.py
+++ b/Qt/config.py
@@ -62,9 +62,13 @@
 
 		"cmake --build . --parallel {jobs} && cmake --install .",
 
-		"cp {buildDir}/libexec/moc {buildDir}/bin",
-		"cp {buildDir}/libexec/rcc {buildDir}/bin",
-		"cp {buildDir}/libexec/uic {buildDir}/bin",
+	],
+
+	"postBuildCopy" : [
+
+		( "{buildDir}/libexec", "moc", "{buildDir}/bin" ),
+		( "{buildDir}/libexec", "rcc", "{buildDir}/bin" ),
+		( "{buildDir}/libexec", "uic", "{buildDir}/bin" ),
 
 	],
 

--- a/USD/config.py
+++ b/USD/config.py
@@ -51,7 +51,12 @@
 		"make install",
 
 		"rm -rf {buildDir}/python/pxr",
-		"mv {buildDir}/lib/python/pxr {buildDir}/python",
+
+	],
+
+	"postBuildMove" : [
+
+		( "{buildDir}/lib/python", "pxr/**/*", "{buildDir}/python" ),
 
 	],
 

--- a/build.py
+++ b/build.py
@@ -8,6 +8,7 @@ import json
 import os
 import operator
 import multiprocessing
+import pathlib
 import subprocess
 import shutil
 import sys
@@ -39,6 +40,13 @@ Dictionary fields
 - enabled : May be set to `False` to disable a project entirely. This is
   only expected to be useful in conjunction with platform overrides or
   variants.
+- postBuildCopy / postBuildMove : List of copy / move directives, each
+  of the form ( sourceRoot, globPattern, destinationRoot ) 
+  specifying paths that should be copied / moved after all `commands`
+  have run. Files in `sourceRoot` that match `globPattern` (including
+  the recursive `**` pattern) are copied / moved, with their path relative
+  to `sourceRoot`, to `destinationRoot`. Destination directories will be
+  created if necessary.
 
 ### Packaging
 
@@ -188,6 +196,8 @@ def __updateDigest( project, config ) :
 	__appendHash( config["digest"], config.get( "environment" ) )
 	__appendHash( config["digest"], config.get( "commands" ) )
 	__appendHash( config["digest"], config.get( "symbolicLinks" ) )
+	__appendHash( config["digest"], config.get( "postBuildCopy" ) )
+	__appendHash( config["digest"], config.get( "postBuildMove" ) )
 	for e in config.get( "requiredEnvironment", [] ) :
 		__appendHash( config["digest"], os.environ.get( e, "" ) )
 
@@ -315,6 +325,19 @@ def __buildProject( project, config, buildDir, cleanup ) :
 	for command in config["commands"] :
 		sys.stderr.write( command + "\n" )
 		subprocess.check_call( command, shell = True, env = environment )
+
+	for operation in [ "postBuildCopy", "postBuildMove" ] :
+		for sourceRoot, pattern, destinationRoot in config.get( operation, () ) :
+			sourceRoot = pathlib.Path( sourceRoot or "." )
+			destinationRoot = pathlib.Path( destinationRoot )
+
+			for p in sourceRoot.glob( pattern ) :
+				destinationPath = destinationRoot / p.relative_to( sourceRoot )
+				destinationPath.parent.mkdir( parents = True, exist_ok = True )
+				if operation == "postBuildCopy" :
+					shutil.copy( p, destinationPath )
+				else :
+					p.replace( destinationPath )
 
 	for link in config.get( "symbolicLinks", [] ) :
 		sys.stderr.write( "Linking {} to {}\n".format( link[0], link[1] ) )

--- a/build.py
+++ b/build.py
@@ -11,6 +11,7 @@ import multiprocessing
 import pathlib
 import subprocess
 import shutil
+import stat
 import sys
 import tarfile
 import zipfile
@@ -346,8 +347,12 @@ def __buildProject( project, config, buildDir, cleanup ) :
 		os.symlink( link[1], link[0] )
 
 	if cleanup :
+		def removeReadonly( func, path, *unused ) :
+			os.chmod( path, stat.S_IWRITE )
+			func( path )
+
 		os.chdir( buildRootDirectory )
-		shutil.rmtree( fullWorkingDir )
+		shutil.rmtree( fullWorkingDir, onexc = removeReadonly )
 
 def __checkConfigs( projects, configs ) :
 


### PR DESCRIPTION
This adds two new configuration operations : one to copy files after the build commands have run, and a companion operation for moving. This is mostly a precursor to introducing more Windows support in the main branch. It will be helpful for resolving differences between copy commands on the different platforms.

I'm hoping the way I've parameterized it is clear enough. I'm mimicking `os.glob()` an introducing a source root to go along with the search pattern. This makes it possible to control where a directory sub-tree should go for both relative and absolute paths.

I checked on a local build that all the same files end up in the archive as the past release and found a couple Qt header files were missing but I'm hoping those are false positives. They seem unrelated to the changes in this PR.