### PR TITLE
USD : Update to version 26.05

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,9 @@
 11.x.x (relative to 11.0.0a6)
 ------
 
-
+- MaterialX : Updated to version 1.39.4.
+- PyBind11 : Updated to version 2.13.6.
+- USD : Updated to version 26.05.
 
 11.0.0a6 (relative to 11.0.0a5)
 --------

--- a/MaterialX/config.py
+++ b/MaterialX/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/MaterialX/archive/refs/tags/v1.39.3.tar.gz",
+		"https://github.com/AcademySoftwareFoundation/MaterialX/archive/refs/tags/v1.39.4.tar.gz",
 
 	],
 

--- a/PyBind11/config.py
+++ b/PyBind11/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"
+		"https://github.com/pybind/pybind11/archive/v2.13.6.tar.gz"
 
 	],
 

--- a/USD/config.py
+++ b/USD/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/PixarAnimationStudios/OpenUSD/archive/refs/tags/v26.03.tar.gz"
+		"https://github.com/PixarAnimationStudios/OpenUSD/archive/refs/tags/v26.05.tar.gz"
 
 	],
 


### PR DESCRIPTION
USD 26.05's default MaterialX version is 1.39.4, which has bumped PyBind11 to 2.13.6.