### PR TITLE
Cycles : Generate tangent patch fix to avoid a crash.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 11.x.x (relative to 11.0.0a5)
 ------
 
-
+- Cycles : Patch to avoid a crash when generating tangents.
 
 11.0.0a5 (relative to 11.0.0a4)
 --------

--- a/Cycles/patches/generateTangentFix.patch
+++ b/Cycles/patches/generateTangentFix.patch
@@ -1,0 +1,20 @@
+--- a/src/scene/geometry.cpp
++++ b/src/scene/geometry.cpp
+@@ -820,6 +820,8 @@ void GeometryManager::device_update(Device *device,
+     }
+ 
+     Mesh *mesh = static_cast<Mesh *>(geom);
++    /* Apply generated attribute if needed or remove if not needed */
++    mesh->update_generated(scene);
+ 
+     if (num_tessellation && mesh->need_tesselation()) {
+       {
+@@ -848,8 +850,6 @@ void GeometryManager::device_update(Device *device,
+       mesh->tessellate(subd_params);
+     }
+ 
+-    /* Apply generated attribute if needed or remove if not needed */
+-    mesh->update_generated(scene);
+     /* Apply tangents for generated and UVs (if any need them) or remove if not needed */
+     mesh->update_tangents(scene, true);
+     if (!mesh->has_true_displacement()) {


### PR DESCRIPTION
This is a patch I will upstream to Blender's main repository. They avoid this crash as the generated attribute aka "Pref" is always generated Blender-side and handed off instead of Cycles creating its own.

The issue was that the generated attribute was made after tessellation and only filled this attribute to the size of the original un-diced mesh. The patch ensures the attribute is created before tessellation and will interpolate after.

The crash was discovered by @murraystevenson here: https://github.com/GafferHQ/gaffer/pull/6885