### PR TITLE
OpenVDB : Update to version 12.1.1

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,9 @@
 11.x.x (relative to 11.0.0a7)
 ------
 
-
+- Nanobind : Added version 2.12.0.
+- OpenVDB : Updated to version 12.1.1.
+- Robin-map : Added version 1.4.1.
 
 11.0.0a7 (relative to 11.0.0a6)
 --------

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 11.x.x (relative to 11.0.0a7)
 ------
 
+- Cortex : Updated to version 10.7.0.0a10.
 - Nanobind : Added version 2.12.0.
 - OpenVDB : Updated to version 12.1.1.
 - PyBind11 : Reverted to version 2.10.4 [^1].

--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,10 @@
 
 - Nanobind : Added version 2.12.0.
 - OpenVDB : Updated to version 12.1.1.
+- PyBind11 : Reverted to version 2.10.4 [^1].
 - Robin-map : Added version 1.4.1.
+
+[^1]: To be omitted from the notes for the final 11.0.0 release.
 
 11.0.0a7 (relative to 11.0.0a6)
 --------

--- a/Cortex/config.py
+++ b/Cortex/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.7.0.0a9.tar.gz"
+		"https://github.com/ImageEngine/cortex/archive/refs/tags/10.7.0.0a10.tar.gz"
 
 	],
 

--- a/Nanobind/config.py
+++ b/Nanobind/config.py
@@ -1,0 +1,35 @@
+{
+
+	"downloads" : [
+
+		"https://github.com/wjakob/nanobind/archive/refs/tags/v2.12.0.tar.gz"
+
+	],
+
+	"url" : "https://nanobind.readthedocs.io",
+
+	"license" : "LICENSE",
+
+	"dependencies" : [ "Python", "Robin-map" ],
+
+	"commands" : [
+
+		"cmake"
+			" -D CMAKE_INSTALL_PREFIX={buildDir}"
+			" -D NB_TEST=0"
+			" -D NB_USE_SUBMODULE_DEPS=0"
+			" .",
+
+		"cmake --install .",
+
+		"cp -r include/nanobind {buildDir}/include",
+
+	],
+
+	"manifest" : [
+
+		"include/nanobind",
+
+	],
+
+}

--- a/OpenImageIO/config.py
+++ b/OpenImageIO/config.py
@@ -10,7 +10,7 @@
 
 	"license" : "LICENSE.md",
 
-	"dependencies" : [ "Boost", "Python", "PyBind11", "OpenEXR", "LibTIFF", "LibPNG", "OpenJPEG", "LibJPEG-Turbo", "OpenColorIO", "LibRaw", "PugiXML", "Fmt", "LibWebP", "TBB", "FreeType" ],
+	"dependencies" : [ "Boost", "Python", "PyBind11", "OpenEXR", "LibTIFF", "LibPNG", "OpenJPEG", "LibJPEG-Turbo", "OpenColorIO", "LibRaw", "PugiXML", "Fmt", "LibWebP", "TBB", "FreeType", "Robin-map" ],
 
 	"environment" : {
 

--- a/OpenShadingLanguage/config.py
+++ b/OpenShadingLanguage/config.py
@@ -10,7 +10,7 @@
 
 	"license" : "LICENSE.md",
 
-	"dependencies" : [ "OpenImageIO", "LLVM", "PugiXML", "Python" ],
+	"dependencies" : [ "OpenImageIO", "LLVM", "PugiXML", "Python", "Robin-map" ],
 
 	"environment" : {
 

--- a/OpenVDB/config.py
+++ b/OpenVDB/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v11.0.0.tar.gz"
+		"https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v12.1.1.tar.gz"
 
 	],
 
@@ -10,7 +10,7 @@
 
 	"license" : "LICENSE",
 
-	"dependencies" : [ "Blosc", "TBB", "OpenEXR", "Python", "Boost", "PyBind11" ],
+	"dependencies" : [ "Blosc", "TBB", "OpenEXR", "Python", "Boost", "Nanobind" ],
 
 	"environment" : {
 
@@ -31,7 +31,7 @@
 			" -D OPENVDB_BUILD_NANOVDB=ON"
 			" -D OPENVDB_ENABLE_RPATH=OFF"
 			" -D CONCURRENT_MALLOC=None"
-			" -D PYOPENVDB_INSTALL_DIRECTORY={buildDir}/python"
+			" -D VDB_PYTHON_INSTALL_DIRECTORY={buildDir}/python"
 			" -D Python_ROOT_DIR={buildDir}"
 			" -D Python_FIND_STRATEGY=LOCATION"
 			" -D Python_FIND_VERSION={pythonVersion}"
@@ -43,15 +43,20 @@
 
 		"cd build && make VERBOSE=1 -j {jobs} && make install",
 
+		# Cortex builds made with OpenVDB 12 and above require nanobind-static.
+		# If/when more projects require Nanobind, we may want to consider building
+		# it independently.
+		"cp build/openvdb/openvdb/python/libnanobind-static.a {buildDir}/lib",
+
 	],
 
 	"manifest" : [
 
 		"include/openvdb",
-		"include/pyopenvdb.h",
 		"include/nanovdb",
 		"lib/libopenvdb*{sharedLibraryExtension}*",
-		"python/pyopenvdb*",
+		"python/openvdb*",
+		"lib/libnanobind-static.a",
 
 	],
 

--- a/PyBind11/config.py
+++ b/PyBind11/config.py
@@ -2,7 +2,7 @@
 
 	"downloads" : [
 
-		"https://github.com/pybind/pybind11/archive/v2.13.6.tar.gz"
+		"https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"
 
 	],
 

--- a/Robin-map/config.py
+++ b/Robin-map/config.py
@@ -1,0 +1,21 @@
+{
+
+	"downloads" : [
+
+		"https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.1.tar.gz"
+
+	],
+
+	"url" : "https://github.com/Tessil/robin-map",
+
+	"license" : "LICENSE",
+
+	"commands" : [
+
+		"mkdir build",
+		"cd build && cmake -D CMAKE_INSTALL_PREFIX={buildDir} ..",
+		"cd build && cmake --build . && cmake --install .",
+
+	],
+
+}


### PR DESCRIPTION
This is the last of the VFX Platform CY2025 updates necessary for Gaffer 1.7, and includes rolling back PyBind11 to 2.10.4 due to the issues encountered on Windows in https://github.com/GafferHQ/gaffer/pull/6928.